### PR TITLE
Fix sqlpp11 build with older cmake version

### DIFF
--- a/external/build-external.sh
+++ b/external/build-external.sh
@@ -35,6 +35,9 @@ curl -L "https://github.com/rbock/sqlpp11/archive/{0.34.tar.gz}" -o "sqlpp11_#1"
 tar xf sqlpp11_0.34.tar.gz
 
 cd sqlpp11-0.34
+
+patch -p1 < ../sqlpp11-0.34.patch
+
 mkdir build
 cd build
 

--- a/external/sqlpp11-0.34.patch
+++ b/external/sqlpp11-0.34.patch
@@ -1,0 +1,27 @@
+diff -rupN sqlpp11-0.34/examples/CMakeLists.txt sqlpp11-0.34.patched/examples/CMakeLists.txt
+--- sqlpp11-0.34/examples/CMakeLists.txt	2015-05-01 18:19:48.000000000 +0200
++++ sqlpp11-0.34.patched/examples/CMakeLists.txt	2015-09-27 12:36:52.774562875 +0200
+@@ -2,7 +2,9 @@
+ macro (build arg)
+ 	# Add headers to sources to enable file browsing in IDEs
+ 	include_directories("${CMAKE_CURRENT_SOURCE_DIR}/../tests")
+-	add_executable("Sqlpp11Example${arg}" "${arg}.cpp" ${sqlpp_headers} "${CMAKE_CURRENT_SOURCE_DIR}/../tests/MockDb.h" "${CMAKE_CURRENT_LIST_DIR}/Sample.h")
++    get_filename_component(_self_dir ${CMAKE_CURRENT_LIST_FILE} PATH)
++	add_executable("Sqlpp11Example${arg}" "${arg}.cpp" ${sqlpp_headers}
++        "${CMAKE_CURRENT_SOURCE_DIR}/../tests/MockDb.h" "${_self_dir}/Sample.h")
+ 	add_test("${arg}" "Sqlpp11Example${arg}")
+ endmacro ()
+ 
+diff -rupN sqlpp11-0.34/tests/CMakeLists.txt sqlpp11-0.34.patched/tests/CMakeLists.txt
+--- sqlpp11-0.34/tests/CMakeLists.txt	2015-05-01 18:19:48.000000000 +0200
++++ sqlpp11-0.34.patched/tests/CMakeLists.txt	2015-09-27 12:36:52.743562567 +0200
+@@ -2,7 +2,8 @@
+ macro (build_and_run arg)
+ 	# Add headers to sources to enable file browsing in IDEs
+ 	include_directories("${CMAKE_BINARY_DIR}/tests")
+-	add_executable("${arg}" "${arg}.cpp" ${sqlpp_headers} "${CMAKE_CURRENT_LIST_DIR}/Sample.h")
++    get_filename_component(_self_dir ${CMAKE_CURRENT_LIST_FILE} PATH)
++	add_executable("${arg}" "${arg}.cpp" ${sqlpp_headers} "${_self_dir}/Sample.h")
+ 	add_test("${arg}" "${CMAKE_BINARY_DIR}/tests/${arg}")
+ endmacro ()
+ 


### PR DESCRIPTION
Even if the cmake file for sqlp11 claims that minimal version of cmake is 2.6, usage of `CMAKE_CURRENT_SOURCE_DIR` makes it dependent on cmake 2.8.

This PR patches CMakeFiles.txt to restore 2.6 compatibility and allows to build on SL6.
