### PR TITLE
Add a new option to display under(over)flow in the first (last) bin

### DIFF
--- a/include/TH1Plotter.h
+++ b/include/TH1Plotter.h
@@ -14,5 +14,6 @@ namespace plotIt {
 
     private:
       void setHistogramStyle(const File& file);
+      void addOverflow(TH1* h, const Plot& plot);
   };
 }

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -193,6 +193,7 @@ namespace plotIt {
     Point fit_legend_position = {0.20, 0.38};
 
     bool show_errors;
+    bool show_overflow = false;
 
     std::string inherits_from;
 
@@ -256,6 +257,7 @@ namespace plotIt {
     std::string root;
 
     bool ignore_scales = false;
+    bool show_overflow = false;
 
     std::string mode = "hist"; // "tree" or "hist"
     std::string tree_name;

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -206,6 +206,9 @@ namespace plotIt {
 
       if (node["tree-name"])
           m_config.tree_name = node["tree-name"].as<std::string>();
+
+      if (node["show-overflow"])
+          m_config.show_overflow = node["show-overflow"].as<bool>();
     }
 
     // Database
@@ -463,6 +466,11 @@ namespace plotIt {
 
       if (node["legend-position"])
         plot.legend_position = node["legend-position"].as<Position>();
+
+      if (node["show-overflow"])
+        plot.show_overflow = node["show-overflow"].as<bool>();
+      else
+        plot.show_overflow = m_config.show_overflow;
 
       if (node["binning-x"])
         plot.binning_x = node["binning-x"].as<uint16_t>();


### PR DESCRIPTION
The corresponding option in the config files is `show-overflow: true/false`.

If `true`, the first and last bin of the plot will contain the under and overflow bins. If the x-axis range is smaller than the original histogram, first and last bins contain respectively the sum of all bins below and above.

Errors are correctly recomputed for these bins.

Before:
![lep1_pt_mumu_bb_no_overflow](https://cloud.githubusercontent.com/assets/386274/10220579/f01eee60-6848-11e5-8630-8103619bf6fe.png)

After:
![lep1_pt_mumu_bb_overflow](https://cloud.githubusercontent.com/assets/386274/10220581/f4ec9adc-6848-11e5-8bbd-6e4f3d8363d5.png)
