### PR TITLE
Support poisson errors

### DIFF
--- a/include/TH1Plotter.h
+++ b/include/TH1Plotter.h
@@ -14,6 +14,6 @@ namespace plotIt {
 
     private:
       void setHistogramStyle(const File& file);
-      void addOverflow(TH1* h, const Plot& plot);
+      void addOverflow(TH1* h, Type type, const Plot& plot);
   };
 }

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -38,6 +38,25 @@ namespace plotIt {
     DATA
   };
 
+  enum ErrorsType {
+      Normal = 0,
+      Poisson = 1,
+      Poisson2 = 2
+  };
+
+  inline ErrorsType string_to_errors_type(const std::string& s) {
+      ErrorsType errors_type;
+
+      if (s == "normal")
+          errors_type = Normal;
+      else if (s == "poisson2")
+          errors_type = Poisson2;
+      else 
+          errors_type = Poisson;
+
+      return errors_type;
+  }
+
   struct PlotStyle;
   class plotIt;
   struct Group;
@@ -205,6 +224,8 @@ namespace plotIt {
 
     Position legend_position;
 
+    ErrorsType errors_type = Poisson;
+
     void print() {
       std::cout << "Plot '" << name << "'" << std::endl;
       std::cout << "\tx_axis: " << x_axis << std::endl;
@@ -261,6 +282,8 @@ namespace plotIt {
 
     std::string mode = "hist"; // "tree" or "hist"
     std::string tree_name;
+
+    ErrorsType errors_type = Poisson;
 
     Configuration() {
       width = height = 800;

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -210,6 +210,10 @@ namespace plotIt {
 
       if (node["show-overflow"])
           m_config.show_overflow = node["show-overflow"].as<bool>();
+
+      m_config.errors_type = Poisson;
+      if (node["errors-type"])
+          m_config.errors_type = string_to_errors_type(node["errors-type"].as<std::string>());
     }
 
     // Database
@@ -472,6 +476,11 @@ namespace plotIt {
         plot.show_overflow = node["show-overflow"].as<bool>();
       else
         plot.show_overflow = m_config.show_overflow;
+
+      if (node["errors-type"])
+        plot.errors_type = string_to_errors_type(node["errors-type"].as<std::string>());
+      else
+        plot.errors_type = m_config.errors_type;
 
       if (node["binning-x"])
         plot.binning_x = node["binning-x"].as<uint16_t>();


### PR DESCRIPTION
Use by default poisson error bars

You can choose what error bars you want with the new `errors-type` key.
Possible values are:
- `normal`: Use standard error bars, defined as sqrt(sumw2)
- `poisson`: Use poisson error bars
- `poisson2`: Use poisson error bars but covering 95%

Poisson errors only make sense for integer bins (ie, data) and are automatically disabled by ROOT when SumW2 is on. In order to ensure poisson errors are used if requested, SumW2 is disabled on data.

PS: This is based on #11
