### PR TITLE
Add support for drawing non-log and log at the same time

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -57,6 +57,19 @@ namespace plotIt {
       return errors_type;
   }
 
+  enum Log {
+    False = 0,
+    True,
+    Both
+  };
+
+  inline Log parse_log(const YAML::Node& node) {
+    if (node.as<std::string>() == "both")
+      return Both;
+    else
+      return node.as<bool>() ? True : False;
+  }
+
   struct PlotStyle;
   class plotIt;
   struct Group;
@@ -181,6 +194,7 @@ namespace plotIt {
 
   struct Plot {
     std::string name;
+    std::string output_name;
     std::string exclude;
 
     bool normalized;

--- a/test/example.yml
+++ b/test/example.yml
@@ -5,7 +5,7 @@ configuration:
   experiment: "CMS"
   extra-label: "Preliminary"
   root: 'files'
-  luminosity: 100
+  luminosity: 1
   luminosity-error: 0.026
   error-fill-style: 3154
   error-fill-color: "#ee556270"
@@ -21,12 +21,26 @@ plots:
     x-axis: "X axis"
     y-axis: "Y axis"
     y-axis-format: "%1% / %2$.0f GeV"
+    y-axis-show-zero: true
+    x-axis-range: [2, 9.5]
+    show-overflow: true
+    show-ratio: true
     normalized: false
+    fit-ratio: true
+    rebin: 4
+    log-y: 'both'
+    save-extensions: ['pdf']
 
   'histo2':
     x-axis: "X axis"
     y-axis: "Y axis"
     normalized: false
+    rebin: 4
+    show-overflow: true
 
 legend:
   position: [0.25, 0.78, 0.45, 0.9]
+
+groups:
+  data:
+    legend: 'Data'


### PR DESCRIPTION
'log-x' and 'log-y' options now support 'both' as an option
in addition to true and false. Using 'both' will draw both log
and non-log plots in the same round.

To avoid overwrite, a suffix is added, either '_logx', '_logy', or
both if needed.
