### PR TITLE
Ensure all the histograms are visible when detecting the lower limit

### DIFF
--- a/include/utilities.h
+++ b/include/utilities.h
@@ -11,6 +11,24 @@ namespace plotIt {
 
   boost::format get_formatter(const std::string format_string);
 
+  #define CAST_AND_CALL(OBJECT, FUNCTION, ...) \
+      if (dynamic_cast<TH1*>(OBJECT)) \
+        FUNCTION(dynamic_cast<TH1*>(OBJECT), ##__VA_ARGS__); \
+      else if (dynamic_cast<THStack*>(OBJECT)) \
+        FUNCTION(dynamic_cast<THStack*>(OBJECT), ##__VA_ARGS__);
+
+  #define CAST_AND_RETURN(OBJECT, FUNCTION, ...) \
+      if (dynamic_cast<TH1*>(OBJECT)) \
+        return FUNCTION(dynamic_cast<TH1*>(OBJECT), ##__VA_ARGS__); \
+      else if (dynamic_cast<THStack*>(OBJECT)) \
+        return FUNCTION(dynamic_cast<THStack*>(OBJECT), ##__VA_ARGS__);
+
+  #define CAST_TO_HIST_AND_CALL(OBJECT, FUNCTION, ...) \
+      if (dynamic_cast<TH1*>(OBJECT)) \
+        FUNCTION(dynamic_cast<TH1*>(OBJECT), ##__VA_ARGS__); \
+      else if (dynamic_cast<THStack*>(OBJECT)) \
+        FUNCTION(dynamic_cast<THStack*>(OBJECT)->GetHistogram(), ##__VA_ARGS__);
+
   template<class T>
     void setAxisTitles(T* object, Plot& plot) {
       if (plot.x_axis.length() > 0 && object->GetXaxis()) {

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -297,21 +297,27 @@ namespace plotIt {
     toDraw[0].first->Draw(toDraw[0].second.c_str());
     setRange(toDraw[0].first, plot);
 
-    float safe_margin = 1.20;
+    float safe_margin = .20;
     if (plot.log_y)
       safe_margin = 8;
 
     if (plot.y_axis_range.size() != 2) {
-      setMaximum(toDraw[0].first, maximum * safe_margin);
+      setMaximum(toDraw[0].first, maximum * (1 + safe_margin));
 
       if (minimum <= 0 && plot.log_y) {
+        std::cout << "Warning: detected minimum is negative (" << minimum << ") but log scale is on. Setting minimum to 0.1" << std::endl;
         minimum = 0.1;
       }
+
+      if (!plot.log_y)
+        minimum = minimum * (1 - std::copysign(safe_margin, minimum));
+      else
+        minimum /= safe_margin;
 
       if (plot.y_axis_show_zero && !plot.log_y)
         minimum = 0;
 
-      setMinimum(toDraw[0].first, minimum * 1.20);
+      setMinimum(toDraw[0].first, minimum);
     }
 
     // First, draw MC

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -124,62 +124,38 @@ namespace plotIt {
   }
 
   void setAxisTitles(TObject* object, Plot& plot) {
-    if (dynamic_cast<TH1*>(object))
-      setAxisTitles(dynamic_cast<TH1*>(object), plot);
-    else if (dynamic_cast<THStack*>(object))
-      setAxisTitles(dynamic_cast<THStack*>(object), plot);
+    CAST_AND_CALL(object, setAxisTitles, plot);
   }
 
   void setDefaultStyle(TObject* object, float topBottomScaleFactor) {
-    if (dynamic_cast<TH1*>(object))
-      setDefaultStyle(dynamic_cast<TH1*>(object), topBottomScaleFactor);
-    else if (dynamic_cast<THStack*>(object))
-      setDefaultStyle(dynamic_cast<THStack*>(object)->GetHistogram(), topBottomScaleFactor);
+    CAST_TO_HIST_AND_CALL(object, setDefaultStyle, topBottomScaleFactor);
   }
 
   void hideXTitle(TObject* object) {
-    if (dynamic_cast<TH1*>(object))
-      hideXTitle(dynamic_cast<TH1*>(object));
-    else if (dynamic_cast<THStack*>(object))
-      hideXTitle(dynamic_cast<THStack*>(object));
+    CAST_AND_CALL(object, hideXTitle);
   }
 
   float getMaximum(TObject* object) {
-    if (dynamic_cast<TH1*>(object))
-      return getMaximum(dynamic_cast<TH1*>(object));
-    else if (dynamic_cast<THStack*>(object))
-      return getMaximum(dynamic_cast<THStack*>(object));
+    CAST_AND_RETURN(object, getMaximum);
 
     return std::numeric_limits<float>::lowest();
   }
 
   float getMinimum(TObject* object) {
-    if (dynamic_cast<TH1*>(object))
-      return getMinimum(dynamic_cast<TH1*>(object));
-    else if (dynamic_cast<THStack*>(object))
-      return getMinimum(dynamic_cast<THStack*>(object));
+    CAST_AND_RETURN(object, getMinimum);
 
     return std::numeric_limits<float>::infinity();
   }
 
-  void setMaximum(TObject* object, float minimum) {
-    if (dynamic_cast<TH1*>(object))
-      setMaximum(dynamic_cast<TH1*>(object), minimum);
-    else if (dynamic_cast<THStack*>(object))
-      setMaximum(dynamic_cast<THStack*>(object), minimum);
+  void setMaximum(TObject* object, float maximum) {
+    CAST_AND_CALL(object, setMaximum, maximum);
   }
 
   void setMinimum(TObject* object, float minimum) {
-    if (dynamic_cast<TH1*>(object))
-      setMinimum(dynamic_cast<TH1*>(object), minimum);
-    else if (dynamic_cast<THStack*>(object))
-      setMinimum(dynamic_cast<THStack*>(object), minimum);
+    CAST_AND_CALL(object, setMinimum, minimum);
   }
 
   void setRange(TObject* object, Plot& plot, bool onlyX/* = false*/) {
-    if (dynamic_cast<TH1*>(object))
-      setRange(dynamic_cast<TH1*>(object), plot, onlyX);
-    else if (dynamic_cast<THStack*>(object))
-      setRange(dynamic_cast<THStack*>(object), plot, onlyX);
+    CAST_AND_CALL(object, setRange, plot, onlyX);
   }
 }


### PR DESCRIPTION
As title says. Sometimes, some backgrounds are missing from the plot because the lower limit (or minimum) is wrongly detected. This should fix the issue.
