### PR TITLE
 Add support for multiple columns in legend

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -169,20 +169,19 @@ namespace plotIt {
     float x2 = 0;
     float y2 = 0;
 
+    Position(float x1, float y1, float x2, float y2):
+        x1(x1), y1(y1), x2(x2), y2(y2) {
+        // Empty
+    }
+
+    Position() = default;
+
     bool operator==(const Position& other) {
       return
         (fabs(x1 - other.x1) < 1e-6) &&
         (fabs(y1 - other.y1) < 1e-6) &&
         (fabs(x2 - other.x2) < 1e-6) &&
         (fabs(y2 - other.y2) < 1e-6);
-    }
-
-    bool empty() const {
-      return
-        (x1 == 0) &&
-        (x2 == 0) &&
-        (y1 == 0) &&
-        (y2 == 0);
     }
   };
 
@@ -237,6 +236,7 @@ namespace plotIt {
     std::string extra_label;
 
     Position legend_position;
+    size_t legend_columns;
 
     ErrorsType errors_type = Poisson;
 
@@ -258,7 +258,8 @@ namespace plotIt {
   };
 
   struct Legend {
-    Position position;
+    Position position = {0.6, 0.6, 0.9, 0.9};
+    size_t columns = 1;
   };
 
   struct Configuration {
@@ -348,7 +349,7 @@ namespace plotIt {
       bool expandObjects(File& file, std::vector<Plot>& plots);
       bool loadObject(File& file, const Plot& plot);
 
-      void addToLegend(TLegend& legend, Type type);
+      void fillLegend(TLegend& legend, const Plot& plot);
 
       void parseLumiLabel();
 

--- a/setup_for_cms_env.sh
+++ b/setup_for_cms_env.sh
@@ -1,0 +1,2 @@
+BOOST_ROOT=`scram tool tag boost BOOST_BASE`
+export BOOST_ROOT

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -1042,7 +1042,7 @@ namespace plotIt {
     else if (file.type == SIGNAL)
       legend_style = "l";
     else if (file.type == DATA)
-      legend_style = "p";
+      legend_style = "pe";
 
     if (node["legend-style"])
       legend_style = node["legend-style"].as<std::string>();

--- a/test/example.yml
+++ b/test/example.yml
@@ -37,9 +37,11 @@ plots:
     normalized: false
     rebin: 4
     show-overflow: true
+    legend-columns: 1
 
 legend:
   position: [0.25, 0.78, 0.45, 0.9]
+  columns: 2
 
 groups:
   data:


### PR DESCRIPTION
The `legend` block now understands `columns`, and the plots now
understand `legend-columns` to set the number of columns in the
legend.

A basic flowing algorithm is used to place the entries in the legend.
The data is always the first entry in the legend. The signal entries
are also added to the first column. If there's more than one, the signal
entries follow directly the data, and the MC entries span over the remaining
columns. If there's only one, the MC entries follow directly the data, and
the signal entries are added after.

Preview:

![legend_1_column](https://cloud.githubusercontent.com/assets/386274/11306450/2234972a-8fb2-11e5-87cf-e620eb632aca.png)

![legend_2_columns](https://cloud.githubusercontent.com/assets/386274/11306454/26c070b6-8fb2-11e5-9ae1-a23657136f77.png)

![legend_3_columns](https://cloud.githubusercontent.com/assets/386274/11306498/7f189bbc-8fb2-11e5-9bcf-7fa9cc2b4a5e.png)

Closes #21 
