### PR TITLE
Add support for fitting the MC distribution

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -157,13 +157,24 @@ namespace plotIt {
   };
 
   struct Point {
-    float x;
-    float y;
+    float x = std::numeric_limits<float>::quiet_NaN();
+    float y = std::numeric_limits<float>::quiet_NaN();
 
     bool operator==(const Point& other) {
       return
         (fabs(x - other.x) < 1e-6) &&
         (fabs(y - other.y) < 1e-6);
+    }
+
+    bool valid() const {
+      return !std::isnan(x) && !std::isnan(y);
+    }
+
+    Point() = default;
+    Point(std::initializer_list<float> c) {
+      assert(c.size() == 2);
+      x = *c.begin();
+      y = *(c.begin() + 1);
     }
   };
 
@@ -225,10 +236,18 @@ namespace plotIt {
     std::vector<std::string> save_extensions;
 
     bool show_ratio;
+
+    bool fit = false;
+    std::string fit_function = "gaus";
+    std::string fit_legend = "#scale[1.6]{#splitline{#mu = %2$.3f}{#sigma = %3$.3f}}";
+    Point fit_legend_position = {0.22, 0.87};
+    Point fit_range;
+
     bool fit_ratio = false;
-    std::string fit_function = "pol1";
-    std::string fit_legend;
-    Point fit_legend_position = {0.20, 0.38};
+    std::string ratio_fit_function = "pol1";
+    std::string ratio_fit_legend;
+    Point ratio_fit_legend_position = {0.20, 0.38};
+    Point ratio_fit_range;
 
     bool show_errors;
     bool show_overflow = false;
@@ -283,6 +302,14 @@ namespace plotIt {
     int16_t error_fill_color;
     int16_t error_fill_style;
 
+    uint16_t fit_n_points = 1000;
+    int16_t fit_line_color = 46;
+    int16_t fit_line_width = 1;
+    int16_t fit_line_style = 1;
+    int16_t fit_error_fill_color = 42;
+    int16_t fit_error_fill_style = 1001;
+
+    uint16_t ratio_fit_n_points = 1000;
     int16_t ratio_fit_line_color = 46;
     int16_t ratio_fit_line_width = 1;
     int16_t ratio_fit_line_style = 1;

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -213,6 +213,7 @@ namespace plotIt {
     std::string uid = get_uuid();
     std::string exclude;
 
+    bool no_data = false;
     bool normalized;
     bool log_y;
     bool log_x;

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -149,7 +149,7 @@ namespace plotIt {
       }
     }
 
-    if ((h_data.get()) && !h_data->GetSumOfWeights())
+    if (plot.no_data || ((h_data.get()) && !h_data->GetSumOfWeights()))
       h_data.reset();
 
     if ((mc_histo_stat_only.get() && !mc_histo_stat_only->GetSumOfWeights())) {

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -250,11 +250,11 @@ namespace plotIt {
     };
 
     // Sort object by minimum
-    std::sort(toDraw.begin(), toDraw.end(), [](std::pair<TObject*, std::string> a, std::pair<TObject*, std::string> b) {
-        return getMinimum(a.first) < getMinimum(b.first);
+    std::sort(toDraw.begin(), toDraw.end(), [&plot](std::pair<TObject*, std::string> a, std::pair<TObject*, std::string> b) {
+        return (!plot.log_y) ? (getMinimum(a.first) < getMinimum(b.first)) : (getPositiveMinimum(a.first) < getPositiveMinimum(b.first));
       });
 
-    float minimum = getMinimum(toDraw[0].first);
+    float minimum = (!plot.log_y) ? getMinimum(toDraw[0].first) : getPositiveMinimum(toDraw[0].first);
 
     // Sort objects by maximum
     std::sort(toDraw.begin(), toDraw.end(), [](std::pair<TObject*, std::string> a, std::pair<TObject*, std::string> b) {
@@ -306,7 +306,7 @@ namespace plotIt {
 
       if (minimum <= 0 && plot.log_y) {
         double old_minimum = minimum;
-        minimum = getPositiveMinimum(toDraw[0].first);
+        minimum = 0.1;
         std::cout << "Warning: detected minimum is negative (" << old_minimum << ") but log scale is on. Setting minimum to " << minimum << std::endl;
       }
 
@@ -475,8 +475,6 @@ namespace plotIt {
     if (hi_pad.get())
       hi_pad->cd();
 
-    return true;
-  
     return true;
   }
 

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -448,6 +448,9 @@ namespace plotIt {
       if (node["normalized"])
         plot.normalized = node["normalized"].as<bool>();
 
+      if (node["no-data"])
+        plot.no_data = node["no-data"].as<bool>();
+
       Log log_y = False;
       if (node["log-y"]) {
         log_y = parse_log(node["log-y"]);
@@ -646,13 +649,15 @@ namespace plotIt {
       };
 
       // First, add data, always on first column
-      for (File& file: m_files) {
-          if (file.type == DATA) {
-              Entry entry;
-              if (getEntryFromFile(file, entry)) {
-                  legend_entries[0].push_back(entry);
-              }
-          }
+      if (!plot.no_data) {
+        for (File& file: m_files) {
+            if (file.type == DATA) {
+                Entry entry;
+                if (getEntryFromFile(file, entry)) {
+                    legend_entries[0].push_back(entry);
+                }
+            }
+        }
       }
 
       // Then MC, spanning on the remaining columns

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -189,6 +189,24 @@ namespace plotIt {
       if (node["error-fill-style"])
         m_config.error_fill_style = loadColor(node["error-fill-style"]);
 
+      if (node["fit-line-style"])
+        m_config.fit_line_style = node["fit-line-style"].as<int16_t>();
+
+      if (node["fit-line-width"])
+        m_config.fit_line_width = node["fit-line-width"].as<int16_t>();
+
+      if (node["fit-line-color"])
+        m_config.fit_line_color = loadColor(node["fit-line-color"]);
+
+      if (node["fit-error-fill-style"])
+        m_config.fit_error_fill_style = node["fit-error-fill-style"].as<int16_t>();
+
+      if (node["fit-error-fill-color"])
+        m_config.fit_error_fill_color = loadColor(node["fit-error-fill-color"]);
+
+      if (node["fit-n-points"])
+        m_config.fit_n_points = node["fit-n-points"].as<uint16_t>();
+
       if (node["ratio-fit-line-style"])
         m_config.ratio_fit_line_style = node["ratio-fit-line-style"].as<int16_t>();
 
@@ -203,6 +221,9 @@ namespace plotIt {
 
       if (node["ratio-fit-error-fill-color"])
         m_config.ratio_fit_error_fill_color = loadColor(node["ratio-fit-error-fill-color"]);
+
+      if (node["ratio-fit-n-points"])
+        m_config.ratio_fit_n_points = node["ratio-fit-n-points"].as<uint16_t>();
 
       if (node["labels"]) {
         YAML::Node labels = node["labels"];
@@ -454,6 +475,9 @@ namespace plotIt {
       if (node["fit-ratio"])
         plot.fit_ratio = node["fit-ratio"].as<bool>();
 
+      if (node["fit"])
+        plot.fit = node["fit"].as<bool>();
+
       if (node["fit-function"])
         plot.fit_function = node["fit-function"].as<std::string>();
 
@@ -462,6 +486,21 @@ namespace plotIt {
 
       if (node["fit-legend-position"])
         plot.fit_legend_position = node["fit-legend-position"].as<Point>();
+
+      if (node["fit-range"])
+        plot.fit_range = node["fit-range"].as<Point>();
+
+      if (node["ratio-fit-function"])
+        plot.ratio_fit_function = node["ratio-fit-function"].as<std::string>();
+
+      if (node["ratio-fit-legend"])
+        plot.ratio_fit_legend = node["ratio-fit-legend"].as<std::string>();
+
+      if (node["ratio-fit-legend-position"])
+        plot.ratio_fit_legend_position = node["ratio-fit-legend-position"].as<Point>();
+
+      if (node["ratio-fit-range"])
+        plot.ratio_fit_range = node["ratio-fit-range"].as<Point>();
 
       if (node["show-errors"])
         plot.show_errors = node["show-errors"].as<bool>();

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -163,13 +163,9 @@ namespace plotIt {
       if (dynamic_cast<TH1*>(object))
           return getPositiveMinimum(dynamic_cast<TH1*>(object));
       else if (dynamic_cast<THStack*>(object)) {
-          float minimum = std::numeric_limits<float>::infinity();
           THStack* stack = dynamic_cast<THStack*>(object);
-          for (size_t n = 0; n < (size_t) stack->GetNhists(); n++) {
-              minimum = std::min(minimum, getPositiveMinimum(static_cast<TH1*>(stack->GetStack()->At(n))));
-          }
-
-          return minimum;
+          size_t n = (size_t) stack->GetNhists() - 1;
+          return getPositiveMinimum(static_cast<TH1*>(stack->GetStack()->At(n)));
       }
 
       return 0;


### PR DESCRIPTION
Provide a simple way to fit the MC distribution using a user-defined formula. Machinery to draw a fit legend is also included.

I've also added an option to explicitly request to not draw the data, `no-data`, and fixed once again the minimum detection in log-y scale.
