### PR TITLE
Produce LaTeX table of yields

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ ROOTCFLAGS = $(shell root-config --cflags)
 ROOTLIBS   = $(shell root-config --noldflags --libs)
 
 CXX           = g++
-CXXFLAGS	    = -g -Wall -fPIC --std=c++0x
+CXXFLAGS	    = -g -Wall -fPIC --std=c++11
 LD			      = g++
 LDDIR         = -L$(shell root-config --libdir) -Lexternal/lib -L$(BOOST_ROOT)/lib/
 LDFLAGS		    = -fPIC $(shell root-config --ldflags) $(LDDIR)

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -109,11 +109,9 @@ namespace plotIt {
     float generated_events;
     float scale;
 
-    // For Data
-    float luminosity;
-
     std::shared_ptr<PlotStyle> plot_style;
-    std::string group;
+    std::string legend_group;
+    std::string yields_group;
 
     Type type;
 
@@ -246,6 +244,12 @@ namespace plotIt {
 
     ErrorsType errors_type = Poisson;
 
+    bool use_for_yields = false;
+    std::string yields_title;
+    int yields_table_order = 0;
+
+    bool is_rescaled = false;
+    
     void print() {
       std::cout << "Plot '" << name << "'" << std::endl;
       std::cout << "\tx_axis: " << x_axis << std::endl;
@@ -302,11 +306,19 @@ namespace plotIt {
     bool ignore_scales = false;
     bool verbose = false;
     bool show_overflow = false;
+    bool do_plots = true;
+    bool do_yields = false;
 
     std::string mode = "hist"; // "tree" or "hist"
     std::string tree_name;
 
     ErrorsType errors_type = Poisson;
+
+    float yields_table_stretch = 1.15;
+    std::string yields_table_align = "h";
+    std::string yields_table_text_align = "c";
+    int yields_table_num_prec_yields = 1;
+    int yields_table_num_prec_ratio = 2;
 
     Configuration() {
       width = height = 800;
@@ -352,6 +364,7 @@ namespace plotIt {
 
       // Plot method
       bool plot(Plot& plot);
+      bool yields(std::vector<Plot>& plots);
 
       bool expandFiles();
       bool expandObjects(File& file, std::vector<Plot>& plots);
@@ -368,7 +381,8 @@ namespace plotIt {
 
       std::vector<File> m_files;
       std::vector<Plot> m_plots;
-      std::map<std::string, Group> m_groups;
+      std::map<std::string, Group> m_legend_groups;
+      std::map<std::string, Group> m_yields_groups;
 
       // Store objects in order to delete everything when drawing is done
       std::vector<std::shared_ptr<TObject>> m_temporaryObjects;

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -35,6 +35,9 @@ namespace plotIt {
       else if (dynamic_cast<THStack*>(OBJECT)) \
         return FUNCTION(dynamic_cast<THStack*>(OBJECT)->GetHistogram(), ##__VA_ARGS__);
 
+  #define ADD_PAIRS(PAIR1, PAIR2) \
+      PAIR1.first += PAIR2.first; PAIR1.second += PAIR2.second;
+
   template<class T>
     void setAxisTitles(T* object, Plot& plot) {
       if (plot.x_axis.length() > 0 && object->GetXaxis()) {
@@ -132,4 +135,6 @@ namespace plotIt {
   }
 
   float getPositiveMinimum(TObject* object);
+
+  void replace_substr(std::string &s, const std::string &old, const std::string &rep);
 }

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -136,5 +136,6 @@ namespace plotIt {
 
   float getPositiveMinimum(TObject* object);
 
+  // replace all occurences of "old" in "s" by "rep"
   void replace_substr(std::string &s, const std::string &old, const std::string &rep);
 }

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -67,6 +67,7 @@ namespace plotIt {
       TH1* h = dynamic_cast<TH1*>(file.object);
 
       if (file.type != DATA) {
+        plot.is_rescaled = true;
         float factor = m_plotIt.getConfiguration().luminosity * file.cross_section * file.branching_ratio / file.generated_events;
         if (! m_plotIt.getConfiguration().ignore_scales) {
           factor *= m_plotIt.getConfiguration().scale * file.scale;

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -213,13 +213,13 @@ namespace plotIt {
             float syst_error_percent = h->GetBinError(i);
             float nominal_value = nominal->GetBinContent(i);
             float syst_error = nominal_value * syst_error_percent;
-            total_syst_error += syst_error;
+            total_syst_error += syst_error * syst_error;
 
             mc_histo_syst_only->SetBinError(i, std::sqrt(total_error * total_error + syst_error * syst_error));
           }
 
           syst.summary.n_events = file.summary.n_events;
-          syst.summary.n_events_error = total_syst_error;
+          syst.summary.n_events_error = std::sqrt(total_syst_error);
         }
       }
 

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -967,13 +967,16 @@ namespace plotIt {
 
         std::string process_name = file.yields_group;
         replace_substr(process_name, "_", "\\_");
+        replace_substr(process_name, "\\", "\\\\");
         std::pair<double, double> yield_sqerror;
         TH1* hist( dynamic_cast<TH1*>(file.object) );
 
-        double factor = m_config.luminosity * file.cross_section * file.branching_ratio / file.generated_events;
-        if( !m_config.ignore_scales )
-          factor *= m_config.scale * file.scale;
-        hist->Scale(factor);
+        if( !plot.is_rescaled ){
+          double factor = m_config.luminosity * file.cross_section * file.branching_ratio / file.generated_events;
+          if( !m_config.ignore_scales )
+            factor *= m_config.scale * file.scale;
+          hist->Scale(factor);
+        }
 
         // Retrieve yield and stat. error
         yield_sqerror.first = hist->IntegralAndError(1, hist->GetNbinsX(), yield_sqerror.second);

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -176,8 +176,8 @@ namespace plotIt {
   }
   
   void replace_substr(std::string &s, const std::string &old, const std::string &rep){
-    size_t pos;
-    while( (pos = s.find(old)) != std::string::npos )
+    size_t pos(0);
+    while( (pos = s.find(old, !pos ? 0 : pos+rep.size())) != std::string::npos )
       s.replace(pos, old.size(), rep);
   }
 }

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -174,4 +174,10 @@ namespace plotIt {
 
       return 0;
   }
+  
+  void replace_substr(std::string &s, const std::string &old, const std::string &rep){
+    size_t pos;
+    while( (pos = s.find(old)) != std::string::npos )
+      s.replace(pos, old.size(), rep);
+  }
 }

--- a/test/TTAnalysis/TT_yields_base.yml
+++ b/test/TTAnalysis/TT_yields_base.yml
@@ -1,0 +1,29 @@
+### YIELDS ###
+
+'Yields_CAT_base_IDLL_IsoLL_jj':
+  #x-axis: ""
+  #y-axis: "Evt"
+  #y-axis-format: "%1%"
+  #normalized: false
+  #x-axis-range: [0, 1]
+  #binning-x: 1
+  #log-y: both
+  #save-extensions: ["png"]
+  #show-ratio: true
+  for-yields: true
+  yields-title: "base, jj"
+  yields-table-order: 0
+
+'Yields_CAT_base_IDLL_IsoLL_bb_LL':
+  #x-axis: ""
+  #y-axis: "Evt"
+  #y-axis-format: "%1%"
+  #normalized: false
+  #x-axis-range: [0, 1]
+  #binning-x: 1
+  #log-y: false
+  #save-extensions: ["png"]
+  #show-ratio: true
+  for-yields: true
+  yields-title: "base, bb"
+  yields-table-order: 1


### PR DESCRIPTION
Add functionality to produce table summarizing yields (data & MC)
- To produce the table, use the '-y' argument. To avoid producing the plots if you only want the table, use the '-p' argument
- Histograms used to produce yields should have the option `for-yields` at true. In principle any histogram can be used for this, but since under/overflow is not taken into account, it is best to use dedicated histograms between 0 and 1, say...
- Each such histogram defines a "category" named using the option `yields-title`
- The order of the category in the table is specified with `yields-table-order`
- In the files config, use the `yields-group` option to specify how samples should be grouped together (similar as what is done for the legend groups). All data is grouped together by default.
- Output is written in a file yields.txt in the output folder, and to standard output if the verbose option is activated
- Output example:

```
\renewcommand{\arraystretch}{1.15}
\begin{tabular}{ |l||c|c|c|c|c||c||c||c| }
        \hline
    Cat. & $t\overline{t}$ diLep. & $t\overline{t}$ other & DY & t-chan. & tW & Tot. MC & Data & Data/MC \\
        \hline
    ElEl, jj & $6447.7 \pm 773.9$ & $64.7 \pm 7.9$ & $51555.0 \pm 6057.5$ & $5.0 \pm 1.2$ & $350.2 \pm 30.8$ & $58422.6 \pm 6106.8$ & $53401$ & $0.91 \pm 0.10$ \\
    ElEl, bb & $3229.0 \pm 387.7$ & $23.3 \pm 3.0$ & $2366.1 \pm 300.8$ & $1.9 \pm 0.6$ & $111.3 \pm 10.5$ & $5731.6 \pm 490.8$ & $4612$ & $0.80 \pm 0.07$ \\
        \hline
\end{tabular}
```

[yields.pdf](https://github.com/cp3-llbb/plotIt/files/64026/yields.pdf)
- For now only one orientation of the table is possible (categories vertically, samples horizontally). If you think the other way around would be useful I'll add it some time...
- Also fixed small bug in the way systematic uncertainties are computed
