### PR TITLE
"Quick tests"

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -212,6 +212,7 @@ namespace plotIt {
     std::string exclude;
 
     bool no_data = false;
+    bool override = false; // flag to plot only those which have it true (if at least one plot has it true)
     bool normalized;
     bool log_y;
     bool log_x;

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -483,6 +483,9 @@ namespace plotIt {
 
       if (node["no-data"])
         plot.no_data = node["no-data"].as<bool>();
+      
+      if (node["override"])
+        plot.override = node["override"].as<bool>();
 
       Log log_y = False;
       if (node["log-y"]) {
@@ -650,6 +653,12 @@ namespace plotIt {
           ++log_counter;
         }
       }
+    }
+
+    // If at least one plot has 'override' set to true, keep only plots which do
+    if( std::find_if(m_plots.begin(), m_plots.end(), [](Plot &plot){ return plot.override; }) != m_plots.end() ){
+      auto new_end = std::remove_if(m_plots.begin(), m_plots.end(), [](Plot &plot){ return !plot.override; });
+      m_plots.erase(new_end, m_plots.end());
     }
 
     parseLumiLabel();


### PR DESCRIPTION
Builds on top of #31 

Add the possibility to quickly add/re-do plots on top of existing ones, without having to comment out every other plot or create a new config file: simply add the `override: true` option to the plots you want to produce, and every plot which doesn't have this option will not be considered.
