### PR TITLE
Add a way to blind data

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -225,6 +225,9 @@ namespace plotIt {
     std::vector<float> x_axis_range;
     std::vector<float> y_axis_range;
 
+    // Blind range
+    Point blinded_range;
+
     uint16_t binning_x;  // Only used in tree mode
     uint16_t binning_y;  // Only used in tree mode
 
@@ -348,6 +351,10 @@ namespace plotIt {
     std::string yields_table_text_align = "c";
     int yields_table_num_prec_yields = 1;
     int yields_table_num_prec_ratio = 2;
+
+    bool unblind = false;
+    int16_t blinded_range_fill_color = 42;
+    int16_t blinded_range_fill_style = 1001;
 
     Configuration() {
       width = height = 800;

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -231,6 +231,12 @@ namespace plotIt {
       if (node["ratio-fit-n-points"])
         m_config.ratio_fit_n_points = node["ratio-fit-n-points"].as<uint16_t>();
 
+      if (node["blinded-range-fill-color"])
+        m_config.blinded_range_fill_color = loadColor(node["blinded-range-fill-color"]);
+
+      if (node["blinded-range-fill-style"])
+        m_config.blinded_range_fill_style = node["blinded-range-fill-style"].as<uint16_t>();
+
       if (node["labels"]) {
         YAML::Node labels = node["labels"];
         m_config.labels = parseLabelsNode(labels);
@@ -551,6 +557,9 @@ namespace plotIt {
 
       if (node["y-axis-range"])
         plot.y_axis_range = node["y-axis-range"].as<std::vector<float>>();
+
+      if (node["blinded-range"])
+        plot.blinded_range = node["blinded-range"].as<Point>();
 
       plot.y_axis_show_zero = false;
       if (node["y-axis-show-zero"])
@@ -1526,6 +1535,8 @@ int main(int argc, char** argv) {
 
     TCLAP::SwitchArg plotsArg("p", "plots", "Do not produce the plots - can be useful if only the yields table is needed", cmd, false);
 
+    TCLAP::SwitchArg unblindArg("u", "unblind", "Unblind the plots, ie ignore any blinded-range in the configuration", cmd, false);
+
     TCLAP::UnlabeledValueArg<std::string> configFileArg("configFile", "configuration file", true, "", "string", cmd);
 
     cmd.parse(argc, argv);
@@ -1549,6 +1560,7 @@ int main(int argc, char** argv) {
     p.getConfigurationForEditing().verbose = verboseArg.getValue();
     p.getConfigurationForEditing().do_plots = !plotsArg.getValue();
     p.getConfigurationForEditing().do_yields = yieldsArg.getValue();
+    p.getConfigurationForEditing().unblind = unblindArg.getValue();
 
     p.plotAll();
 

--- a/test/example.yml
+++ b/test/example.yml
@@ -12,6 +12,8 @@ configuration:
   ratio-fit-error-fill-style: 1001
   ratio-fit-error-fill-color: "#aa556270"
   ratio-fit-line-color: "#0B486B"
+  blinded-range-fill-color: "#29556270"
+  blinded-range-fill-style: 1001
 
 files:
   include: ['example_files.yml']
@@ -30,6 +32,7 @@ plots:
     rebin: 4
     log-y: 'both'
     save-extensions: ['pdf']
+    blinded-range: [3, 5.2]
 
   'histo2':
     x-axis: "X axis"


### PR DESCRIPTION
Specify the range to blind using the new `blinded-range` plot option.

A rectangle is drawn over the plot to indicate the blinded area. You can control the fill color and the fill style of this rectangle with the new configuration options `blinded-range-fill-color` and `blinded-range-fill-style`. You can see an implementation in `test/example.yml`.

Preview:
![preview_blinded_area](https://cloud.githubusercontent.com/assets/386274/11914277/8aca60ae-a67c-11e5-982d-f5ef7c5144cb.png)

Use the command-line option `--unblind` to unblind all the plots.
