### PR TITLE
Fix yaml-cpp build with cmake 2.6

### DIFF
--- a/external/build-external.sh
+++ b/external/build-external.sh
@@ -5,6 +5,8 @@
 curl -O -J -L https://github.com/jbeder/yaml-cpp/archive/release-0.5.3.tar.gz
 tar xf yaml-cpp-release-0.5.3.tar.gz
 
+patch -p0 < yaml-cpp-cmake-fix.patch
+
 cd yaml-cpp-release-0.5.3
 mkdir build
 cd build

--- a/external/yaml-cpp-cmake-fix.patch
+++ b/external/yaml-cpp-cmake-fix.patch
@@ -1,0 +1,11 @@
+--- yaml-cpp-release-0.5.3/CMakeLists.txt.orig	2016-01-27 10:40:22.850198491 +0100
++++ yaml-cpp-release-0.5.3/CMakeLists.txt	2016-01-27 10:38:59.768508189 +0100
+@@ -308,7 +308,7 @@
+ export(
+     TARGETS yaml-cpp
+     FILE "${PROJECT_BINARY_DIR}/yaml-cpp-targets.cmake")
+-export(PACKAGE yaml-cpp)
++#export(PACKAGE yaml-cpp)
+ set(EXPORT_TARGETS yaml-cpp CACHE INTERNAL "export targets")
+ 
+ set(CONFIG_INCLUDE_DIRS "${YAML_CPP_SOURCE_DIR}/include")


### PR DESCRIPTION
Temporary fix until the issue is resolved upstream. See https://github.com/jbeder/yaml-cpp/issues/361
