### PR TITLE
Add a way to restrict which sample a systematics affects

### DIFF
--- a/examples/example.yml
+++ b/examples/example.yml
@@ -23,6 +23,7 @@ systematics:
   - beta: {type: shape}  # Shape systematics
   - gamma: {type: ln, prior: 1.072, pretty-name: "Gamma"}  # Log-normal systematics, +7.2%, -2.97%, exp(+/- 1 * log(prior))
   - delta: 1.14  # Constant systematics, +- 14%
+  - epsilon: {type: const, value: 1.08, on: 'sample1'}
 
 plots:
   'histo1':

--- a/include/systematics.h
+++ b/include/systematics.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <memory>
+#include <regex>
 
 namespace YAML {
     class Node;
@@ -55,6 +56,7 @@ namespace plotIt {
 
         std::string name;
         std::string pretty_name;
+        std::regex on;
 
         /**
          * Apply the systematic on the given set

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -1200,7 +1200,8 @@ namespace plotIt {
 
         if (file.type != DATA) {
           for (auto& syst: m_systematics) {
-              file.systematics_cache[plot.uid].push_back(syst->newSet(cloned_obj.get(), file, plot));
+              if (std::regex_search(file.path, syst->on))
+                  file.systematics_cache[plot.uid].push_back(syst->newSet(cloned_obj.get(), file, plot));
           }
         }
 

--- a/src/systematics.cc
+++ b/src/systematics.cc
@@ -204,12 +204,18 @@ namespace plotIt {
 
         if (result) {
             result->name = name;
+            result->pretty_name = name;
 
-            if (node.IsMap() && node["pretty-name"]) {
-                result->pretty_name = node["pretty-name"].as<std::string>();
-            } else {
-                result->pretty_name = name;
+            std::string on = ".*";
+            if (node.IsMap()) {
+                if (node["pretty-name"])
+                    result->pretty_name = node["pretty-name"].as<std::string>();
+
+                if (node["on"])
+                    on = node["on"].as<std::string>();
             }
+
+            result->on = std::regex(on, std::regex_constants::icase);
 
             return result;
         }


### PR DESCRIPTION
Add a new `on` option to the systematics declaration. It's a regular expression which specify which sample the systematics affect. The regex is matched on the sample filename. It's useful for cross-section uncertainties for example.
