### PR TITLE
Fix crash on ingrid when using regex

### DIFF
--- a/src/systematics.cc
+++ b/src/systematics.cc
@@ -215,7 +215,7 @@ namespace plotIt {
                     on = node["on"].as<std::string>();
             }
 
-            result->on = std::regex(on, std::regex_constants::icase);
+            result->on = std::regex(on);
 
             return result;
         }


### PR DESCRIPTION
Fix a crash on ingrid due to some locale issue. I have no time to properly investigate the issue, so in the mean time, fix it by making the regex case sensitive.
