### PR TITLE
Optimize globbing operation

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -35,7 +35,8 @@ namespace plotIt {
 
   class plotIt {
     public:
-      plotIt(const fs::path& outputPath, const std::string& configFile);
+      plotIt(const fs::path& outputPath);
+      void parseConfigurationFile(const std::string& file);
       void plotAll();
 
       std::vector<File>& getFiles() {
@@ -56,7 +57,6 @@ namespace plotIt {
 
     private:
       void checkOrThrow(YAML::Node& node, const std::string& name, const std::string& file);
-      void parseConfigurationFile(const std::string& file);
       void parseIncludes(YAML::Node& node);
       void parseSystematicsNode(const YAML::Node& node);
 


### PR DESCRIPTION
First, only list the content of the first file if at least one plot has
a globbing operator (*, ? or [), as most of the times there's not.

Second, if user use some globbing, the content of the files is read
once, and a string representation of the file's content is built,
without actually reading the objects inside the file. Globbing is then
performed on the representation, and not on the file's structure itself.
