### PR TITLE
Add an option to save all the plots to a ROOT file

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -390,6 +390,9 @@ namespace plotIt {
 
     int16_t blinded_range_fill_color = 42;
     int16_t blinded_range_fill_style = 1001;
+
+    std::string book_keeping_file_name;
+    std::shared_ptr<TFile> book_keeping_file;
   };
 }
 

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -61,6 +61,8 @@ namespace plotIt {
   template<class T>
     void setDefaultStyle(T* object, float topBottomScaleFactor) {
 
+      // Remove title
+      object->SetBit(TH1::kNoTitle);
       object->SetLabelFont(43, "XYZ");
       object->SetTitleFont(43, "XYZ");
       object->SetLabelSize(LABEL_FONTSIZE, "XYZ");
@@ -75,6 +77,9 @@ namespace plotIt {
       object->GetXaxis()->SetTitleOffset(1.5 * topBottomScaleFactor);
       object->GetXaxis()->SetLabelOffset(0.012 * topBottomScaleFactor);
       object->GetXaxis()->SetTickLength(0.03);
+
+      // No stats box
+      object->SetStats(false);
       
     }
 

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -430,6 +430,15 @@ namespace plotIt {
     // First, draw MC
     if (mc_stack.get()) {
       mc_stack->Draw("same");
+
+      // Clear all the possible stats box remaining
+      mc_stack->GetHistogram()->SetStats(false);
+      TIter next(mc_stack->GetHists());
+      TH1* h = nullptr;
+      while ((h = static_cast<TH1*>(next()))) {
+          h->SetStats(false);
+      }
+
       TemporaryPool::get().add(mc_stack);
     }
 


### PR DESCRIPTION
This will help storing the results in SAMAdhi. An new option is available in the `configuration` section,
`book-keeping-file`, which takes the name of the output ROOT file. All the plots are saved in this ROOT file.

I've also done some cleaning so that the rendering of the previously saved canvas from the file is the same that the plot saved by plotIt (Histograms titles and stats box were visible when drawing the canvas).
