### PR TITLE
Fix globbing

### DIFF
--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -1513,7 +1513,10 @@ namespace plotIt {
                   continue;
               }
 
-              content.push_back(prefix + "/" + name);
+              std::string new_prefix = prefix;
+              if (!new_prefix.empty())
+                  new_prefix += "/";
+              content.push_back(new_prefix + name);
           }
       }
   }


### PR DESCRIPTION
Using a `*` in plot name is broken since a while. This PR fixes it.

@swertz can you test to ensure it solves your issue?
