### PR TITLE
Lumi improvement

### DIFF
--- a/examples/example.yml
+++ b/examples/example.yml
@@ -1,7 +1,7 @@
 configuration:
   width: 800
   height: 800
-  luminosity-label: '%lumi% fb^{-1} (8 TeV)'
+  luminosity-label: '%1$.2f fb^{-1} (8 TeV)'
   experiment: "CMS"
   extra-label: "Preliminary"
   root: 'files'

--- a/examples/example_folders.yml
+++ b/examples/example_folders.yml
@@ -1,7 +1,7 @@
 configuration:
   width: 800
   height: 800
-  luminosity-label: '%lumi% fb^{-1} (8 TeV)'
+  luminosity-label: '%1$.2f fb^{-1} (8 TeV)'
   experiment: "CMS"
   extra-label: "Preliminary"
   root: 'files'

--- a/examples/example_trees.yml
+++ b/examples/example_trees.yml
@@ -1,7 +1,7 @@
 configuration:
   width: 800
   height: 800
-  luminosity-label: '%lumi% fb^{-1} (8 TeV)'
+  luminosity-label: '%1$.2f fb^{-1} (8 TeV)'
   experiment: "CMS"
   extra-label: "Preliminary"
   root: 'files'

--- a/examples/example_with_groups.yml
+++ b/examples/example_with_groups.yml
@@ -1,7 +1,7 @@
 configuration:
   width: 800
   height: 800
-  luminosity-label: '%lumi% fb^{-1} (8 TeV)'
+  luminosity-label: '%1$.2f fb^{-1} (8 TeV)'
   experiment: "CMS"
   extra-label: "Preliminary"
   root: 'files'

--- a/include/types.h
+++ b/include/types.h
@@ -340,6 +340,7 @@ namespace plotIt {
     float height = 800;
     float luminosity = -1;
     float scale = 1;
+    bool no_lumi_rescaling = false;
 
     // Systematics
     float luminosity_error_percent = 0;

--- a/include/types.h
+++ b/include/types.h
@@ -372,7 +372,6 @@ namespace plotIt {
     std::string extra_label;
 
     std::string lumi_label;
-    std::string lumi_label_parsed;
 
     std::string root = "./";
 

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -76,7 +76,13 @@ namespace plotIt {
 
       if (file.type != DATA) {
         plot.is_rescaled = true;
-        float factor = m_plotIt.getConfiguration().luminosity * file.cross_section * file.branching_ratio / file.generated_events;
+
+        float factor = file.cross_section * file.branching_ratio / file.generated_events;
+
+        if (! m_plotIt.getConfiguration().no_lumi_rescaling) {
+          factor *= m_plotIt.getConfiguration().luminosity;
+        }
+
         if (! CommandLineCfg::get().ignore_scales) {
           factor *= m_plotIt.getConfiguration().scale * file.scale;
         }

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -200,6 +200,9 @@ namespace plotIt {
         throw YAML::ParserException(YAML::Mark::null_mark(), "'configuration' block is missing luminosity");
       }
 
+      if (node["no-lumi-rescaling"])
+        m_config.no_lumi_rescaling = node["no-lumi-rescaling"].as<bool>();
+
       if (node["luminosity-error"]) {
         float value = node["luminosity-error"].as<float>();
 
@@ -996,7 +999,11 @@ namespace plotIt {
         std::pair<double, double> yield_sqerror;
         TH1* hist( dynamic_cast<TH1*>(file.object) );
 
-        double factor = m_config.luminosity * file.cross_section * file.branching_ratio / file.generated_events;
+        double factor = file.cross_section * file.branching_ratio / file.generated_events;
+
+        if (! m_config.no_lumi_rescaling) {
+          factor *= m_config.luminosity;
+        }
         if (!CommandLineCfg::get().ignore_scales)
           factor *= m_config.scale * file.scale;
 

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -660,15 +660,12 @@ namespace plotIt {
 
   void plotIt::parseLumiLabel() {
 
-    m_config.lumi_label_parsed = m_config.lumi_label;
+    boost::format formatter = get_formatter(m_config.lumi_label);
 
     float lumi = m_config.luminosity / 1000.;
+    formatter % lumi;
 
-    std::ostringstream out;
-    out << std::fixed << std::setprecision(2) << lumi;
-    std::string lumiStr = out.str();
-
-    boost::algorithm::replace_all(m_config.lumi_label_parsed, "%lumi%", lumiStr);
+    m_config.lumi_label = formatter.str();
   }
 
   void plotIt::fillLegend(TLegend& legend, const Plot& plot, bool with_uncertainties) {
@@ -846,7 +843,7 @@ namespace plotIt {
     TGaxis::SetExponentOffset(-0.06, 0, "y");
 
     // Luminosity label
-    if (m_config.lumi_label_parsed.length() > 0) {
+    if (m_config.lumi_label.length() > 0) {
       std::shared_ptr<TPaveText> pt = std::make_shared<TPaveText>(LEFT_MARGIN, 1 - 0.5 * topMargin, 1 - RIGHT_MARGIN, 1, "brNDC");
       TemporaryPool::get().add(pt);
 
@@ -857,7 +854,7 @@ namespace plotIt {
       pt->SetTextSize(0.6 * topMargin);
       pt->SetTextAlign(33);
 
-      pt->AddText(m_config.lumi_label_parsed.c_str());
+      pt->AddText(m_config.lumi_label.c_str());
       pt->Draw();
     }
 


### PR DESCRIPTION
Two things:
- Add `no-lumi-rescaling` options to not rescale backgrounds to lumi if needed
- Luminosity is now formatted using boost::format like everything else, so you'll need to update your `luminosity-label` string to remove `%lumi%` and to use `%1$.2f` (note than you can control the number of significant figures)
