### PR TITLE
Better support for directories inside ROOT files

### DIFF
--- a/examples/example.yml
+++ b/examples/example.yml
@@ -14,6 +14,8 @@ configuration:
   ratio-fit-line-color: "#0B486B"
   blinded-range-fill-color: "#29556270"
   blinded-range-fill-style: 1001
+  yields-table-align: v
+  book-keeping-file: 'plots.root'
 
 files:
   include: ['example_files.yml']
@@ -41,6 +43,7 @@ plots:
     log-y: 'both'
     save-extensions: ['pdf']
     blinded-range: [3, 5.2]
+    book-keeping-folder: 'coucou/toi'
 
   'histo2':
     x-axis: "X axis"

--- a/examples/example_folders.yml
+++ b/examples/example_folders.yml
@@ -5,29 +5,36 @@ configuration:
   experiment: "CMS"
   extra-label: "Preliminary"
   root: 'files'
-  luminosity: 100
-  luminosity-error: 0.026
+  luminosity: 1
+  luminosity-error: 0.046
   error-fill-style: 3154
   error-fill-color: "#ee556270"
   ratio-fit-error-fill-style: 1001
   ratio-fit-error-fill-color: "#aa556270"
   ratio-fit-line-color: "#0B486B"
-  labels: 
-    - text: "coucou"
-      position: [0.1, 0.3]
-      size: 18
+  blinded-range-fill-color: "#29556270"
+  blinded-range-fill-style: 1001
+  yields-table-align: v
+  book-keeping-file: 'plots.root'
 
 files:
   include: ['example_files.yml']
 
+systematics:
+  - alpha # Shape systematics
+  - beta: {type: shape}  # Shape systematics
+  - gamma: {type: ln, prior: 1.072, pretty-name: "Gamma"}  # Log-normal systematics, +7.2%, -2.97%, exp(+/- 1 * log(prior))
+  - delta: 1.14  # Constant systematics, +- 14%
+  - epsilon: {type: const, value: 1.08, on: 'sample1'}
+
 plots:
-  'test/histo1':
+  '*histo1':
     x-axis: "X axis"
     y-axis: "Y axis"
     y-axis-format: "%1% / %2$.0f GeV"
     normalized: false
 
-  'test/histo2':
+  '*histo2':
     x-axis: "X axis"
     y-axis: "Y axis"
     normalized: false

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -15,6 +15,7 @@
 #include <vector>
 #include <string>
 #include <glob.h>
+#include <unordered_map>
 
 #include <types.h>
 #include <defines.h>
@@ -78,6 +79,8 @@ namespace plotIt {
       std::vector<SystematicPtr> m_systematics;
       std::map<std::string, Group> m_legend_groups;
       std::map<std::string, Group> m_yields_groups;
+
+      std::unordered_map<std::string, TDirectory*> m_book_keeping_folders;
 
       // Current style
       std::shared_ptr<TStyle> m_style;

--- a/include/types.h
+++ b/include/types.h
@@ -257,6 +257,7 @@ namespace plotIt {
     std::string output_suffix;
     std::string uid = get_uuid();
     std::string exclude;
+    std::string book_keeping_folder;
 
     bool no_data = false;
     bool override = false; // flag to plot only those which have it true (if at least one plot has it true)

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -179,4 +179,6 @@ namespace plotIt {
           return str;
       }
   }
+
+  TDirectory* getDirectory(TDirectoryFile* root, const boost::filesystem::path& directory, bool create = true);
 }

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -217,4 +217,25 @@ namespace plotIt {
       return node.as<int16_t>();
     }
   }
+
+  namespace fs = boost::filesystem;
+
+  TDirectory* getDirectory(TDirectoryFile* root, const boost::filesystem::path& path, bool create/* = true*/) {
+
+      TDirectoryFile* local_root = root;
+
+      for (const auto& folder: path) {
+          TDirectoryFile* ptr = nullptr;
+          local_root->GetObject(folder.c_str(), ptr);
+
+          if (! ptr && create) {
+              // No leak here, memory is managed by the file itself...
+              ptr = new TDirectoryFile(folder.c_str(), folder.c_str(), "", local_root);
+          }
+
+          local_root = ptr;
+      }
+
+      return local_root;
+  }
 }

--- a/test/generate_files_folders.C
+++ b/test/generate_files_folders.C
@@ -5,7 +5,32 @@
 #include <TFormula.h>
 #include <TF1.h>
 
-#include <iostream>
+TH1* get_constant_variation(TH1* i, const std::string& name, double factor) {
+
+    TH1* result = (TH1*) i->Clone(name.c_str());
+    //result->SetDirectory(nullptr);
+
+    result->Scale(factor);
+
+    return result;
+}
+
+TH1* get_variation(TH1* i, const std::string& name, double pivot, double slop) {
+
+    double b = - slop * pivot;
+
+    auto tf = new TF1("variation", "[0] + [1]*x", 0, 10);
+    tf->SetParameters(b, slop);
+
+    TH1* result = (TH1*) i->Clone(name.c_str());
+    //result->SetDirectory(nullptr);
+
+    for (size_t i = 1; i <= result->GetNbinsX(); i++) {
+        result->SetBinContent(i, result->GetBinContent(i) + tf->Eval(result->GetBinCenter(i)));
+    }
+
+    return result;
+}
 
 void generate_files_folders() {
     const float luminosity = 1;
@@ -17,7 +42,6 @@ void generate_files_folders() {
     const float mc2_xsection = 666.3;
 
     const uint32_t n_data = luminosity * ( mc1_xsection + mc2_xsection);
-    std::cout << n_data << std::endl;
 
     auto sqroot = new TFormula("sqroot", "x*gaus(0) + [3]*abs(sin(x)/x)");
     auto sqroot_tf = new TF1("sqroot_tf", "sqroot", 0, 10);
@@ -25,13 +49,19 @@ void generate_files_folders() {
 
     // MC1 file
     auto f_mc1 = TFile::Open("files/MC_sample1.root", "recreate");
-    f_mc1->mkdir("test")->cd();
+    f_mc1->mkdir("folder")->cd();
 
     auto h1_mc1 = new TH1F("histo1", "histo1", 200, 0, 10);
     h1_mc1->FillRandom("sqroot_tf", mc1_gen_events);
-    
+
     auto h2_mc1 = new TH1F("histo2", "histo2", 200, -3, 3);
     h2_mc1->FillRandom("gaus", mc1_gen_events);
+
+    h1_alpha_up_mc1 = get_constant_variation(h1_mc1, "histo1__alphaup", 1.06);
+    h1_alpha_down_mc1 = get_constant_variation(h1_mc1, "histo1__alphadown", 0.93);
+
+    h1_beta_up_mc1 = get_variation(h1_mc1, "histo1__betaup", 3, 1.10);
+    h1_beta_down_mc1 = get_variation(h1_mc1, "histo1__betadown", 3, -1.10);
 
     f_mc1->Write();
 
@@ -41,13 +71,19 @@ void generate_files_folders() {
     sqroot_tf2->SetParameters(10, 8, 1.3, 20);
 
     auto f_mc2 = TFile::Open("files/MC_sample2.root", "recreate");
-    f_mc2->mkdir("test")->cd();
+    f_mc2->mkdir("folder")->cd();
 
     auto h1_mc2 = new TH1F("histo1", "histo1", 200, 0, 10);
     h1_mc2->FillRandom("sqroot_tf2", mc2_gen_events);
-    
+
     auto h2_mc2 = new TH1F("histo2", "histo2", 200, -3, 3);
     h2_mc2->FillRandom("gaus", mc2_gen_events);
+
+    h1_alpha_up_mc2 = get_constant_variation(h1_mc2, "histo1__alphaup", 1.09);
+    h1_alpha_down_mc2 = get_constant_variation(h1_mc2, "histo1__alphadown", 0.97);
+
+    h1_beta_up_mc2 = get_variation(h1_mc2, "histo1__betaup", 3, 0.6);
+    h1_beta_down_mc2 = get_variation(h1_mc2, "histo1__betadown", 3, -1.50);
 
     f_mc2->Write();
 
@@ -62,7 +98,7 @@ void generate_files_folders() {
     h2_sum->Add(h2_mc2, luminosity * mc2_xsection / mc2_gen_events);
 
     auto f_data = TFile::Open("files/data.root", "recreate");
-    f_data->mkdir("test")->cd();
+    f_data->mkdir("folder")->cd();
 
     auto h1_data = new TH1F("histo1", "histo1", 200, 0, 10);
     h1_data->FillRandom(h1_sum, n_data);


### PR DESCRIPTION
The same layout as the input file is now used when saving the plots on
disk but also in the book-keeping output file. It's possible to override
the structure using the new `book-keeping-folder` plot option.
