### PR TITLE
Ensure X errors are not shown on data

### DIFF
--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -482,7 +482,7 @@ namespace plotIt {
 
     // And finally data
     if (h_data.get()) {
-      data_drawing_options += " E X0 same";
+      data_drawing_options += " same";
       h_data->Draw(data_drawing_options.c_str());
       TemporaryPool::get().add(h_data);
     }

--- a/src/types.cc
+++ b/src/types.cc
@@ -29,7 +29,7 @@ namespace plotIt {
       if (type == MC || type == SIGNAL)
         drawing_options = "hist";
       else if (type == DATA)
-        drawing_options = "P";
+        drawing_options = "P E X0";
     }
 
     marker_size = -1;


### PR DESCRIPTION
Currently, only the second draw of the data histogram had the `X0` options. If, by accident, the histogram with the maximum bin is the data one, it would be draw _with_ X error bars. As such, all the point without MC behind would have an error bar, which is definitively not wanted.
