### PR TITLE
Avoid SetBinContent for overflow and underflow bins

### DIFF
--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -861,16 +861,22 @@ namespace plotIt {
     for (size_t i = 0; i < first_bin; i++) {
       underflow += h->GetBinContent(i);
       underflow_sumw2 += (h->GetBinError(i) * h->GetBinError(i));
-      h->SetBinContent(i, 0); // Clear bin content so that Integral() still returns the right value
     }
-
     float overflow = 0;
     float overflow_sumw2 = 0;
     for (size_t i = last_bin + 1; i <= (size_t) h->GetNbinsX() + 1; i++) {
       overflow += h->GetBinContent(i);
       overflow_sumw2 += (h->GetBinError(i) * h->GetBinError(i));
-      h->SetBinContent(i, 0); // Clear bin content so that Integral() still returns the right value
     }
+    // Clear out-of-range bin content so that Integral() still returns the right value
+    for (size_t i = 0; i < first_bin-1; i++) {
+      h->SetBinContent(i, 0);
+    }
+    for (size_t i = last_bin + 1; i < (size_t) h->GetNbinsX() + 1; i++) {
+      h->SetBinContent(i, 0);
+    }
+    // Clear also underflow and overflow bins (SetBinContent on these may try to extend the axes)
+    h->ClearUnderflowAndOverflow();
 
     float first_bin_content = h->GetBinContent(first_bin);
     float first_bin_sumw2 = h->GetBinError(first_bin) * h->GetBinError(first_bin);

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -869,7 +869,7 @@ namespace plotIt {
       overflow_sumw2 += (h->GetBinError(i) * h->GetBinError(i));
     }
     // Clear out-of-range bin content so that Integral() still returns the right value
-    for (size_t i = 0; i < first_bin-1; i++) {
+    for (size_t i = 1; i < first_bin; i++) {
       h->SetBinContent(i, 0);
     }
     for (size_t i = last_bin + 1; i < (size_t) h->GetNbinsX() + 1; i++) {


### PR DESCRIPTION
ROOT feature of the day: if you set labels for all your x-axis bins (e.g. flavour categories), the x-axis becomes alphanumeric and extendable automatically. `SetBinContent` beyond the limits then automatically grows it (see https://root.cern.ch/doc/master/TH1_8cxx_source.html#l08278)
`plotIt` got stuck in an infinite loop because of that (I think because `GetNbinsX()`  picks up the new value right away). This should fix it, but I'm open to better suggestions (e.g. `UpdateBinContent(i, 0.)` for all bins, trying to detect such histograms (I don't see the `IsAlphanumeric` method in the ROOT we have in 76, but it is there in the documentation for the master branch - we could use `CanExtend` instead) etc.) - let me know what you think...
