### PR TITLE
Support globbing for input files

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -37,7 +37,7 @@ namespace plotIt {
   class plotIt {
     public:
       plotIt(const fs::path& outputPath);
-      void parseConfigurationFile(const std::string& file);
+      bool parseConfigurationFile(const std::string& file);
       void plotAll();
 
       std::vector<File>& getFiles() {

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -246,7 +246,8 @@ namespace plotIt {
     if (plot.no_data || ((h_data.get()) && !h_data->GetSumOfWeights()))
       h_data.reset();
 
-    if ((mc_histo_stat_only.get() && !mc_histo_stat_only->GetSumOfWeights())) {
+    // Ensure there's MC events
+    if (mc_stack && !mc_stack->GetHists()) {
       mc_histo_stat_only.reset();
       mc_stack.reset();
     }
@@ -504,6 +505,7 @@ namespace plotIt {
 
       // Clear all the possible stats box remaining
       mc_stack->GetHistogram()->SetStats(false);
+
       TIter next(mc_stack->GetHists());
       TH1* h = nullptr;
       while ((h = static_cast<TH1*>(next()))) {


### PR DESCRIPTION
Add support for globbing for the input files. Expressions using `*` or `?` will now correctly be expanded.

For example, you can now use:

```
'DoubleMuon_Run2016*.root':
  type: data
  group: "Data"
```

to match all files starting with `DoubleMuon_Run2016` (useful when there's 9 run period in 2016 :smile:)