### PR TITLE
Add support for x/y axis label size

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -340,6 +340,10 @@ namespace plotIt {
     bool sort_by_yields = true;
 
     std::vector<Line> lines;
+
+    // Axis label size
+    float x_axis_label_size = LABEL_FONTSIZE;
+    float y_axis_label_size = LABEL_FONTSIZE;
     
     void print() {
       std::cout << "Plot '" << name << "'" << std::endl;
@@ -441,6 +445,10 @@ namespace plotIt {
 
     std::string book_keeping_file_name;
     std::shared_ptr<TFile> book_keeping_file;
+
+    // Axis label size
+    float x_axis_label_size = LABEL_FONTSIZE;
+    float y_axis_label_size = LABEL_FONTSIZE;
   };
 }
 

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -59,7 +59,7 @@ namespace plotIt {
   void setAxisTitles(TObject* object, Plot& plot);
 
   template<class T>
-    void setDefaultStyle(T* object, float topBottomScaleFactor) {
+    void setDefaultStyle(T* object, Plot& plot, float topBottomScaleFactor) {
 
       // Remove title
       object->SetBit(TH1::kNoTitle);
@@ -73,18 +73,19 @@ namespace plotIt {
       object->GetYaxis()->SetTitleOffset(2.5);
       object->GetYaxis()->SetLabelOffset(0.01);
       object->GetYaxis()->SetTickLength(0.03);
+      object->GetYaxis()->SetLabelSize(plot.y_axis_label_size);
 
       object->GetXaxis()->SetTitleOffset(1.5 * topBottomScaleFactor);
       object->GetXaxis()->SetLabelOffset(0.012 * topBottomScaleFactor);
       object->GetXaxis()->SetTickLength(0.03);
+      object->GetXaxis()->SetLabelSize(plot.x_axis_label_size);
 
       // No stats box
       object->SetStats(false);
       
     }
 
-  void setDefaultStyle(TObject* object, float topBottomScaleFactor);
-
+  void setDefaultStyle(TObject* object, Plot& plot, float topBottomScaleFactor);
 
   template<class T>
     void hideXTitle(T* object) {

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -642,7 +642,7 @@ namespace plotIt {
 
     // Set x and y axis titles, and default style
     for (auto& obj: toDraw) {
-      setDefaultStyle(obj.first, (plot.show_ratio) ? 0.6666 : 1.);
+      setDefaultStyle(obj.first, plot, (plot.show_ratio) ? 0.6666 : 1.);
       setAxisTitles(obj.first, plot);
     }
 
@@ -736,7 +736,7 @@ namespace plotIt {
       h_low_pad_axis->Reset(); // Keep binning
       setRange(h_low_pad_axis.get(), x_axis_range, plot.ratio_y_axis_range);
 
-      setDefaultStyle(h_low_pad_axis.get(), 1. / 0.3333);
+      setDefaultStyle(h_low_pad_axis.get(), plot, 3.);
       h_low_pad_axis->GetYaxis()->SetTickLength(0.04);
       h_low_pad_axis->GetYaxis()->SetNdivisions(505, true);
       h_low_pad_axis->GetXaxis()->SetTickLength(0.07);

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -421,6 +421,14 @@ namespace plotIt {
 
       if (node["book-keeping-file"])
         m_config.book_keeping_file_name = node["book-keeping-file"].as<std::string>();
+
+      // Axis size
+      if (node["x-axis-label-size"])
+        m_config.x_axis_label_size = node["x-axis-label-size"].as<float>();
+
+      if (node["y-axis-label-size"])
+        m_config.y_axis_label_size = node["y-axis-label-size"].as<float>();
+
     }
 
     // Retrieve files/processes configuration
@@ -698,6 +706,17 @@ namespace plotIt {
       if (node["sort-by-yields"]) {
         plot.sort_by_yields = node["sort-by-yields"].as<bool>();
       }
+
+      // Axis size
+      if (node["x-axis-label-size"])
+        plot.x_axis_label_size = node["x-axis-label-size"].as<float>();
+      else
+        plot.x_axis_label_size = m_config.x_axis_label_size;
+
+      if (node["y-axis-label-size"])
+        plot.y_axis_label_size = node["y-axis-label-size"].as<float>();
+      else
+        plot.y_axis_label_size = m_config.y_axis_label_size;
 
       // Handle log
       std::vector<bool> logs_x;

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -131,8 +131,8 @@ namespace plotIt {
     CAST_AND_CALL(object, setAxisTitles, plot);
   }
 
-  void setDefaultStyle(TObject* object, float topBottomScaleFactor) {
-    CAST_TO_HIST_AND_CALL(object, setDefaultStyle, topBottomScaleFactor);
+  void setDefaultStyle(TObject* object, Plot& plot, float topBottomScaleFactor) {
+    CAST_TO_HIST_AND_CALL(object, setDefaultStyle, plot, topBottomScaleFactor);
   }
 
   void hideXTitle(TObject* object) {


### PR DESCRIPTION
Adds two new options: `x-axis-label-size` and `y-axis-label-size` to control the size of the labels. Default value is 18 as it's used to be.