### PR TITLE
Add a way to disable ticks on opposite axes

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -449,6 +449,10 @@ namespace plotIt {
     // Axis label size
     float x_axis_label_size = LABEL_FONTSIZE;
     float y_axis_label_size = LABEL_FONTSIZE;
+
+    // Show or not opposite axis ticks
+    bool x_axis_top_ticks = true;
+    bool y_axis_right_ticks = true;
   };
 }
 

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -7,7 +7,9 @@
 #include <boost/format.hpp>
 
 namespace plotIt {
-  TStyle* createStyle();
+  struct Configuration;
+
+  TStyle* createStyle(const Configuration& config);
 
   boost::format get_formatter(const std::string format_string);
 

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -62,7 +62,6 @@ namespace plotIt {
       createPlotters(*this);
 
       gErrorIgnoreLevel = kError;
-      m_style.reset(createStyle());
 
       TH1::AddDirectory(false);
     }
@@ -429,6 +428,11 @@ namespace plotIt {
       if (node["y-axis-label-size"])
         m_config.y_axis_label_size = node["y-axis-label-size"].as<float>();
 
+      if (node["x-axis-top-ticks"])
+        m_config.x_axis_top_ticks = node["x-axis-top-ticks"].as<bool>();
+
+      if (node["y-axis-right-ticks"])
+        m_config.y_axis_right_ticks = node["y-axis-right-ticks"].as<bool>();
     }
 
     // Retrieve files/processes configuration
@@ -1433,6 +1437,9 @@ namespace plotIt {
   }
 
   void plotIt::plotAll() {
+
+    m_style.reset(createStyle(m_config));
+
     // First, explode plots to match all glob patterns
 
     std::vector<Plot> plots;

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -1,5 +1,6 @@
 #include <pool.h>
 #include <utilities.h>
+#include <types.h>
 
 #include <yaml-cpp/yaml.h>
 
@@ -10,7 +11,7 @@
 
 namespace plotIt {
 
-  TStyle* createStyle() {
+  TStyle* createStyle(const Configuration& config) {
     TStyle *style = new TStyle("style", "style");
 
     // For the canvas:
@@ -102,10 +103,11 @@ namespace plotIt {
 
     style->SetAxisColor(1, "XYZ");
     style->SetStripDecimals(kTRUE);
-    style->SetTickLength(0.03, "XYZ");
+    style->SetTickLength(0.02, "XYZ");
     style->SetNdivisions(510, "XYZ");
-    style->SetPadTickX(1);  // To get tick marks on the opposite side of the frame
-    style->SetPadTickY(1);
+
+    style->SetPadTickX(config.x_axis_top_ticks ? 1 : 0);  // To get tick marks on the opposite side of the frame
+    style->SetPadTickY(config.y_axis_right_ticks ? 1 : 0);
 
     style->SetOptLogx(0);
     style->SetOptLogy(0);


### PR DESCRIPTION
Title says all. There's two new boolean options in the `configuration` section: `x-axis-top-ticks` and `y-axis-right-ticks`. They default to `true` to preserve backward compatibility.