### PR TITLE
New options to hide ticks and set line locations

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -350,6 +350,10 @@ namespace plotIt {
     // Axis label size
     float x_axis_label_size = LABEL_FONTSIZE;
     float y_axis_label_size = LABEL_FONTSIZE;
+
+    // Show or hide ticks for each axis
+    bool x_axis_hide_ticks = false;
+    bool y_axis_hide_ticks = false;
     
     void print() {
       std::cout << "Plot '" << name << "'" << std::endl;

--- a/include/types.h
+++ b/include/types.h
@@ -26,6 +26,11 @@ namespace plotIt {
     DATA
   };
 
+  enum Location {
+    TOP,
+    BOTTOM
+  };
+
   inline Type string_to_type(const std::string& type) {
       if (type == "signal")
           return SIGNAL;
@@ -245,6 +250,7 @@ namespace plotIt {
     Point end;
 
     boost::optional<LineStyle> style;
+    Location pad = TOP;
 
     bool operator==(const Line& other) {
       return ((start == other.start) && (end == other.end));

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -138,6 +138,16 @@ namespace plotIt {
   void setRange(TObject* object, const Range& x_range, const Range& y_range);
 
   template<class T>
+    void hideTicks(T* object, bool for_x, bool for_y) {
+      if (for_x)
+        object->GetXaxis()->SetTickLength(0);
+
+      if (for_y)
+        object->GetYaxis()->SetTickLength(0);
+    }
+  void hideTicks(TObject* object, bool for_x, bool for_y);
+
+  template<class T>
     Range getXRange(T* object) {
       Range range;
       range.start = object->GetXaxis()->GetBinLowEdge(object->GetXaxis()->GetFirst());

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -573,6 +573,8 @@ namespace plotIt {
     toDraw[0].first->Draw(toDraw[0].second.c_str());
     setRange(toDraw[0].first, x_axis_range, y_axis_range);
 
+    hideTicks(toDraw[0].first, plot.x_axis_hide_ticks, plot.y_axis_hide_ticks);
+
     float safe_margin = .20;
     if (plot.log_y)
       safe_margin = 8;
@@ -644,6 +646,7 @@ namespace plotIt {
     for (auto& obj: toDraw) {
       setDefaultStyle(obj.first, plot, (plot.show_ratio) ? 0.6666 : 1.);
       setAxisTitles(obj.first, plot);
+      hideTicks(obj.first, plot.x_axis_hide_ticks, plot.y_axis_hide_ticks);
     }
 
     gPad->Modified();
@@ -743,6 +746,8 @@ namespace plotIt {
       h_low_pad_axis->GetYaxis()->SetTickLength(0.04);
       h_low_pad_axis->GetYaxis()->SetNdivisions(505, true);
       h_low_pad_axis->GetXaxis()->SetTickLength(0.07);
+
+      hideTicks(h_low_pad_axis.get(), plot.x_axis_hide_ticks, plot.y_axis_hide_ticks);
 
       h_low_pad_axis->Draw();
 

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -689,12 +689,11 @@ namespace plotIt {
         blinded_area->Draw("same");
     }
 
-    // Draw all the requested lines for this plot
-    auto resolveLine = [&](Line& line) {
+    auto drawLine = [&](Line& line, TVirtualPad* pad) {
         Range x_range = getXRange(toDraw[0].first);
 
-        float y_range_start = gPad->GetUymin();
-        float y_range_end = gPad->GetUymax();
+        float y_range_start = pad->GetUymin();
+        float y_range_end = pad->GetUymax();
 
         if (std::isnan(line.start.x))
             line.start.x = x_range.start;
@@ -707,19 +706,23 @@ namespace plotIt {
 
         if (std::isnan(line.end.y))
             line.end.y = y_range_end;
+
+        std::shared_ptr<TLine> l(new TLine(line.start.x, line.start.y, line.end.x, line.end.y));
+        TemporaryPool::get().add(l);
+
+        l->SetLineColor(line.style->line_color);
+        l->SetLineWidth(line.style->line_width);
+        l->SetLineStyle(line.style->line_type);
+
+        l->Draw("same");
     };
 
     for (Line& line: plot.lines) {
-      resolveLine(line);
+      // Only keep TOP lines
+      if (line.pad != TOP)
+        continue;
 
-      std::shared_ptr<TLine> l(new TLine(line.start.x, line.start.y, line.end.x, line.end.y));
-      TemporaryPool::get().add(l);
-
-      l->SetLineColor(line.style->line_color);
-      l->SetLineWidth(line.style->line_width);
-      l->SetLineStyle(line.style->line_type);
-
-      l->Draw("same");
+      drawLine(line, hi_pad ? hi_pad.get() : gPad);
     }
 
     // Redraw only axis
@@ -841,6 +844,17 @@ namespace plotIt {
 
       // Hide top pad label
       hideXTitle(toDraw[0].first);
+
+      low_pad->Modified();
+      low_pad->Update();
+
+      for (Line& line: plot.lines) {
+        // Only keep BOTTOM lines
+        if (line.pad != BOTTOM)
+          continue;
+
+        drawLine(line, low_pad.get());
+      }
 
       TemporaryPool::get().add(h_low_pad_axis);
       TemporaryPool::get().add(ratio);

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -722,6 +722,13 @@ namespace plotIt {
       else
         plot.y_axis_label_size = m_config.y_axis_label_size;
 
+      // Show or hide ticks
+      if (node["x-axis-hide-ticks"])
+        plot.x_axis_hide_ticks = node["x-axis-hide-ticks"].as<bool>();
+
+      if (node["y-axis-hide-ticks"])
+        plot.y_axis_hide_ticks = node["y-axis-hide-ticks"].as<bool>();
+
       // Handle log
       std::vector<bool> logs_x;
       std::vector<bool> logs_y;

--- a/src/types.cc
+++ b/src/types.cc
@@ -98,6 +98,12 @@ namespace plotIt {
       YAML::Node configuration = node;
       if (node.Type() == YAML::NodeType::Map) {
           style = LineStyle(node);
+          if (node["pad-location"]) {
+            std::string l = node["pad-location"].as<std::string>();
+            if (l == "bottom")
+              pad = BOTTOM;
+          }
+
           configuration = node["value"];
       }
 

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -165,6 +165,10 @@ namespace plotIt {
     CAST_AND_CALL(object, setRange, x_range, y_range);
   }
 
+  void hideTicks(TObject* object, bool for_x, bool for_y) {
+    CAST_AND_CALL(object, hideTicks, for_x, for_y);
+  }
+
   Range getXRange(TObject* object) {
     CAST_AND_RETURN(object, getXRange);
 


### PR DESCRIPTION
Two new sets of options:

  - `x-axis-hide-ticks` or `y-axis-hide-ticks` to hide ticks for a given axis
  - `pad-location` option for line. If set to `bottom`, the line will be draw on the bottom frame, if possible.

Note: based on top of #92, I'll rebase once merged