### PR TITLE
Change treatment of relative paths

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -37,7 +37,7 @@ namespace plotIt {
   class plotIt {
     public:
       plotIt(const fs::path& outputPath);
-      bool parseConfigurationFile(const std::string& file);
+      bool parseConfigurationFile(const std::string& file, const fs::path& histogramsPath);
       void plotAll();
 
       std::vector<File>& getFiles() {

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -54,7 +54,7 @@ namespace plotIt {
 
     private:
       void checkOrThrow(YAML::Node& node, const std::string& name, const std::string& file);
-      void parseIncludes(YAML::Node& node);
+      void parseIncludes(YAML::Node& node, const fs::path& base);
       void parseSystematicsNode(const YAML::Node& node);
       void parseFileNode(File& file, const YAML::Node& key, const YAML::Node& value);
       void parseFileNode(File& file, const YAML::Node& node);


### PR DESCRIPTION
The idea behind these two commits is to allow running `plotIt` from any directory, without having to change the config when using a new version of the histograms. The default behaviour should be the same as before.

Previously, both included config files and histogram files were (implicitly) searched for starting from the current directory. I would propose to:
- use the directory of the main configuration file as base for including configuration files (and the level above in case of nested includes)
- allow specifying the histograms "root base path" (to be prepended to the one in the config, if that is relative) from the command-line (still the current directory by default).

Testing done: (in `$CMSSW_BASE/cp3-llbb/plotIt`) `./plotIt -i test -o tmp examples/example.yml`