### PR TITLE
Fix tests for latest ROOT versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ addons:
     - libboost-filesystem1.55-dev
     - libboost-regex1.55-dev
     - libboost-system1.55-dev
+    - libgsl0ldbl
+    - ghostscript
 install:
 - export CXX=g++-4.9
 - export CC=gcc-4.9

--- a/test/generate_files.C
+++ b/test/generate_files.C
@@ -56,11 +56,11 @@ void generate_files() {
     auto h2_mc1 = new TH1F("histo2", "histo2", 200, -3, 3);
     h2_mc1->FillRandom("gaus", mc1_gen_events);
 
-    h1_alpha_up_mc1 = get_constant_variation(h1_mc1, "histo1__alphaup", 1.06);
-    h1_alpha_down_mc1 = get_constant_variation(h1_mc1, "histo1__alphadown", 0.93);
+    auto h1_alpha_up_mc1 = get_constant_variation(h1_mc1, "histo1__alphaup", 1.06);
+    auto h1_alpha_down_mc1 = get_constant_variation(h1_mc1, "histo1__alphadown", 0.93);
 
-    h1_beta_up_mc1 = get_variation(h1_mc1, "histo1__betaup", 3, 1.10);
-    h1_beta_down_mc1 = get_variation(h1_mc1, "histo1__betadown", 3, -1.10);
+    auto h1_beta_up_mc1 = get_variation(h1_mc1, "histo1__betaup", 3, 1.10);
+    auto h1_beta_down_mc1 = get_variation(h1_mc1, "histo1__betadown", 3, -1.10);
 
     f_mc1->Write();
 
@@ -77,11 +77,11 @@ void generate_files() {
     auto h2_mc2 = new TH1F("histo2", "histo2", 200, -3, 3);
     h2_mc2->FillRandom("gaus", mc2_gen_events);
 
-    h1_alpha_up_mc2 = get_constant_variation(h1_mc2, "histo1__alphaup", 1.09);
-    h1_alpha_down_mc2 = get_constant_variation(h1_mc2, "histo1__alphadown", 0.97);
+    auto h1_alpha_up_mc2 = get_constant_variation(h1_mc2, "histo1__alphaup", 1.09);
+    auto h1_alpha_down_mc2 = get_constant_variation(h1_mc2, "histo1__alphadown", 0.97);
 
-    h1_beta_up_mc2 = get_variation(h1_mc2, "histo1__betaup", 3, 0.6);
-    h1_beta_down_mc2 = get_variation(h1_mc2, "histo1__betadown", 3, -1.50);
+    auto h1_beta_up_mc2 = get_variation(h1_mc2, "histo1__betaup", 3, 0.6);
+    auto h1_beta_down_mc2 = get_variation(h1_mc2, "histo1__betadown", 3, -1.50);
 
     f_mc2->Write();
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -2,4 +2,7 @@
 
 root -l -b -q generate_files.C &> /dev/null
 
+[[ -d tmp ]] || mkdir tmp
+export TMPDIR=$(pwd)/tmp
+
 python tests.py

--- a/test/unit_tests/tests.py
+++ b/test/unit_tests/tests.py
@@ -6,6 +6,7 @@ import unittest
 import shutil
 import yaml
 import tempfile
+import subprocess
 
 from configuration import get_configuration
 
@@ -125,9 +126,6 @@ class plotItSimpleTestCase(unittest.TestCase):
         self.__generate_golden_images = False
 
     def run_plotit(self, configuration):
-        import subprocess
-        import tempfile
-
         with tempfile.NamedTemporaryFile() as yml:
             yml.write(yaml.dump(configuration))
             yml.flush()


### PR DESCRIPTION
ROOT now (finally!) enforces specifying the type when declaring variables in macros.