### PR TITLE
Make the pad margins configurable

### DIFF
--- a/include/defines.h
+++ b/include/defines.h
@@ -3,8 +3,3 @@
 #define TITLE_FONTSIZE 26
 #define LABEL_FONTSIZE 18
 
-#define LEFT_MARGIN 0.17
-#define RIGHT_MARGIN 0.03
-#define TOP_MARGIN 0.05
-#define BOTTOM_MARGIN 0.13
-

--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -44,7 +44,7 @@ namespace plotIt {
         return m_files;
       }
 
-      Configuration getConfiguration() const {
+      const Configuration& getConfiguration() const {
         return m_config;
       }
 

--- a/include/types.h
+++ b/include/types.h
@@ -398,6 +398,10 @@ namespace plotIt {
   struct Configuration {
     float width = 800;
     float height = 800;
+    float margin_left = 0.17;
+    float margin_right = 0.03;
+    float margin_top = 0.05;
+    float margin_bottom = 0.13;
     float luminosity = -1;
     float scale = 1;
     bool no_lumi_rescaling = false;

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -527,17 +527,18 @@ namespace plotIt {
     if (plot.show_ratio) {
       hi_pad = std::make_shared<TPad>("pad_hi", "", 0., 0.33333, 1, 1);
       hi_pad->Draw();
-      hi_pad->SetTopMargin(TOP_MARGIN / .6666);
-      hi_pad->SetLeftMargin(LEFT_MARGIN);
+      const auto& config = m_plotIt.getConfiguration();
+      hi_pad->SetTopMargin(config.margin_top / .6666);
+      hi_pad->SetLeftMargin(config.margin_left);
       hi_pad->SetBottomMargin(0.015);
-      hi_pad->SetRightMargin(RIGHT_MARGIN);
+      hi_pad->SetRightMargin(config.margin_right);
 
       low_pad = std::make_shared<TPad>("pad_lo", "", 0., 0., 1, 0.33333);
       low_pad->Draw();
-      low_pad->SetLeftMargin(LEFT_MARGIN);
+      low_pad->SetLeftMargin(config.margin_left);
       low_pad->SetTopMargin(1.);
-      low_pad->SetBottomMargin(BOTTOM_MARGIN / .3333);
-      low_pad->SetRightMargin(RIGHT_MARGIN);
+      low_pad->SetBottomMargin(config.margin_bottom / .3333);
+      low_pad->SetRightMargin(config.margin_right);
       low_pad->SetTickx(1);
 
       hi_pad->cd();

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -297,6 +297,18 @@ namespace plotIt {
       if (node["height"])
         m_config.height = node["height"].as<float>();
 
+      if (node["margin-left"])
+        m_config.margin_left = node["margin-left"].as<float>();
+
+      if (node["margin-right"])
+        m_config.margin_right = node["margin-right"].as<float>();
+
+      if (node["margin-top"])
+        m_config.margin_top = node["margin-top"].as<float>();
+
+      if (node["margin-bottom"])
+        m_config.margin_bottom = node["margin-bottom"].as<float>();
+
       if (node["experiment"])
         m_config.experiment = node["experiment"].as<std::string>();
 
@@ -956,7 +968,7 @@ namespace plotIt {
 
     legend.Draw();
 
-    float topMargin = TOP_MARGIN;
+    float topMargin = m_config.margin_top;
     if (plot.show_ratio)
       topMargin /= .6666;
 
@@ -965,7 +977,7 @@ namespace plotIt {
 
     // Luminosity label
     if (m_config.lumi_label.length() > 0) {
-      std::shared_ptr<TPaveText> pt = std::make_shared<TPaveText>(LEFT_MARGIN, 1 - 0.5 * topMargin, 1 - RIGHT_MARGIN, 1, "brNDC");
+      std::shared_ptr<TPaveText> pt = std::make_shared<TPaveText>(m_config.margin_left, 1 - 0.5 * topMargin, 1 - m_config.margin_right, 1, "brNDC");
       TemporaryPool::get().add(pt);
 
       pt->SetFillStyle(0);
@@ -981,7 +993,7 @@ namespace plotIt {
 
     // Experiment
     if (m_config.experiment.length() > 0) {
-      std::shared_ptr<TPaveText> pt = std::make_shared<TPaveText>(LEFT_MARGIN, 1 - 0.5 * topMargin, 1 - RIGHT_MARGIN, 1, "brNDC");
+      std::shared_ptr<TPaveText> pt = std::make_shared<TPaveText>(m_config.margin_left, 1 - 0.5 * topMargin, 1 - m_config.margin_right, 1, "brNDC");
       TemporaryPool::get().add(pt);
 
       pt->SetFillStyle(0);

--- a/src/utilities.cc
+++ b/src/utilities.cc
@@ -73,10 +73,10 @@ namespace plotIt {
     style->SetStatW(0.15);
 
     // Margins:
-    style->SetPadTopMargin(TOP_MARGIN);
-    style->SetPadBottomMargin(BOTTOM_MARGIN);
-    style->SetPadLeftMargin(LEFT_MARGIN);
-    style->SetPadRightMargin(RIGHT_MARGIN);
+    style->SetPadTopMargin(config.margin_top);
+    style->SetPadBottomMargin(config.margin_bottom);
+    style->SetPadLeftMargin(config.margin_left);
+    style->SetPadRightMargin(config.margin_right);
 
     // For the Global title:
     style->SetOptTitle(0);


### PR DESCRIPTION
They can be set through the "margin-left", "margin-right", "margin-bottom" and "margin-top" keys in the "configuration" block.

Testing done: tests pass; I also made plots in a different format (more rectangular and without ratio panel), with the left margin reduced and the bottom margin slightly increased - the options work as intended