### PR TITLE
Also allow specifying 'order' at the group level

### DIFF
--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -507,7 +507,20 @@ namespace plotIt {
       group.plot_style->loadFromYAML(node, file->type);
 
       m_legend_groups[group.name] = group;
+
+      if ( node["order"] ) {
+        const auto groupOrder = node["order"].as<int16_t>();
+        for ( auto& file : m_files ) {
+          if ( ( file.legend_group == group.name ) && ( file.order == std::numeric_limits<int16_t>::min() ) ) {
+            file.order = groupOrder;
+          }
+        }
+      }
     }
+
+    std::sort(m_files.begin(), m_files.end(), [](const File& a, const File& b) {
+      return a.order < b.order;
+     });
 
     // Remove non-existant groups from files and update yields group
     for (auto& file: m_files) {


### PR DESCRIPTION
Since usually the contributions of a group are displayed as if they were one contribution to the distribution, it is quite convenient if the 'order' key doesn't have to be specified for every single one of them (additional advantage: if including the same 'files' block from different top-level configurations, the order needs not be the same - as long as the definition of the groups is compatible). The group order value is only used if none is specified for the file.

I added another sort of the files afterwards (and did not remove the one above) in order not to change the behaviour of [these lines](https://github.com/pieterdavid/plotIt/blob/e207ca9d91e03a4ee4e7cea2b311ebe6b0dcf56a/src/plotIt.cc#L496-L507)