### PR TITLE
Specify draw style for ratio

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -411,6 +411,7 @@ namespace plotIt {
 
     std::string y_axis_format = "%1% / %2$.2f";
     std::string ratio_y_axis_title = "Data / MC";
+    std::string ratio_style = "P0";
 
     int16_t error_fill_color = 42;
     int16_t error_fill_style = 3154;

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -758,7 +758,7 @@ namespace plotIt {
       auto& mc_stack = mc_stacks.begin()->second;
 
       std::shared_ptr<TGraphAsymmErrors> ratio = getRatio(h_data.get(), mc_stack.stat_only.get());
-      ratio->Draw("P0 same");
+      ratio->Draw((m_plotIt.getConfiguration().ratio_style + "same").c_str());
 
       // Compute systematic errors
       std::shared_ptr<TH1> h_systematics(static_cast<TH1*>(h_low_pad_axis->Clone()));
@@ -849,7 +849,7 @@ namespace plotIt {
       }
 
       h_low_pad_axis->Draw("same");
-      ratio->Draw("P0 same");
+      ratio->Draw((m_plotIt.getConfiguration().ratio_style + "same").c_str());
 
       // Hide top pad label
       hideXTitle(toDraw[0].first);

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -415,6 +415,9 @@ namespace plotIt {
       if (node["ratio-y-axis"])
         m_config.ratio_y_axis_title = node["ratio-y-axis"].as<std::string>();
 
+      if (node["ratio-style"])
+        m_config.ratio_style = node["ratio-style"].as<std::string>();
+
       if (node["mode"])
           m_config.mode = node["mode"].as<std::string>();
 


### PR DESCRIPTION
With a little ingeniosity with the config file (*), plotIt can be made to plot data vs. data and MC vs. MC comparisons (with ratios). However in some cases this messes up the uncertainties of the TGraphAsymmErros used to draw the ratio... I'll check why that happens but in the meanwhile it's simpler to be able to specify the draw style for the ratio, to simply avoid drawing the uncertainties.

(*) Hint: one contribution needs to be specified as "MC", the other as "data". The draw style of each group (`drawing-options`, `legend-style` etc.) can be changed as liked. The luminosity has to be set to `1.`. And with this PR, the ratio style has to be changed to `ratio-style: 'PX'`.
