### PR TITLE
Fix to era filter: files without era should always be selected

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -69,7 +69,7 @@ namespace plotIt {
         return result;
       }
       bool filter_eras(const File& file) const {
-        return m_config.eras.empty() || ( std::end(m_config.eras) != std::find(std::begin(m_config.eras), std::end(m_config.eras), file.era) );
+        return m_config.eras.empty() || file.era.empty() || ( std::end(m_config.eras) != std::find(std::begin(m_config.eras), std::end(m_config.eras), file.era) );
       }
       file_list getFiles() const { return getFiles(std::bind(&plotIt::filter_eras, this, std::placeholders::_1)); }
 


### PR DESCRIPTION
Minor fix for #115 : when eras are specified at the top-level configuration, but not for one/some of the sample, the sample should be added anyway (it's quite a corner case, but this is in line with the specified/documented behaviour).