### PR TITLE
Update TCLAP download url to mirror/tclap on github

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ add_dependencies(yaml-cpp yaml-cpp-build)
 set_target_properties(yaml-cpp PROPERTIES IMPORTED_LOCATION ${CMAKE_CURRENT_BINARY_DIR}/external/lib/libyaml-cpp.a)
 ExternalProject_Add(
   tclap
-  URL https://github.com/eile/tclap/archive/tclap-1-2-1-release-final.tar.gz
+  URL https://github.com/mirror/tclap/archive/tclap-1-2-1-release-final.tar.gz
   BUILD_IN_SOURCE 1
   PATCH_COMMAND ./autotools.sh
   CONFIGURE_COMMAND ./configure --prefix=${CMAKE_CURRENT_BINARY_DIR}/external

--- a/external/build-external.sh
+++ b/external/build-external.sh
@@ -18,7 +18,7 @@ cd ../..
 rm yaml-cpp-0.6.2.tar.gz
 
 # TCLAP
-curl -L "https://github.com/eile/tclap/archive/tclap-1-2-1-release-final.tar.gz" -o "tclap-1.2.1.tar.gz"
+curl -L "https://github.com/mirror/tclap/archive/tclap-1-2-1-release-final.tar.gz" -o "tclap-1.2.1.tar.gz"
 tar xf tclap-1.2.1.tar.gz
 mv tclap-tclap-1-2-1-release-final tclap-1.2.1
 


### PR DESCRIPTION
https://github.com/eile/tclap gives a 404, but the same is available from a few forks - I picked one that looked minimal