### PR TITLE
Update travis to the latest available platform and ROOT version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,51 +1,43 @@
-dist: trusty
+dist: bionic
 sudo: false
 language: cpp
 compiler:
 - gcc
 env:
-- ROOT_VERSION=6.06.02
+- ROOT_VERSION=6.18.04
 addons:
   apt:
-    sources:
-    - ubuntu-toolchain-r-test
-    - kalakris-cmake
-    - boost-latest
     packages:
-    - gcc-4.9
-    - g++-4.9
+    - libboost-dev
+    - libboost-filesystem-dev
+    - libboost-regex-dev
+    - libboost-system-dev
     - git
     - make
-    - libboost1.55-dev
-    - libboost-filesystem1.55-dev
-    - libboost-regex1.55-dev
-    - libboost-system1.55-dev
-    - libgsl0ldbl
     - ghostscript
     - cmake
 before_install:
-- export CXX=g++-4.9
-- export CC=gcc-4.9
 - export PATH=$HOME/.local/bin:$PATH
 - pip install --user pyyaml requests
-- wget http://cp3.irmp.ucl.ac.be/~delaere/MoMEMta/ROOT-${ROOT_VERSION}_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64.tar.xz
-- tar xf ROOT-${ROOT_VERSION}_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64.tar.xz
-- source ROOT-${ROOT_VERSION}_Python-2.7_gcc-4.9.3_Ubuntu_14.04_x86_64/bin/thisroot.sh
+- wget https://root.cern/download/root_v6.18.04.Linux-ubuntu18-x86_64-gcc7.4.tar.gz
+- tar xf root_v${ROOT_VERSION}.Linux-ubuntu18-x86_64-gcc7.4.tar.gz
+- cd root
+- . bin/thisroot.sh
+- cd ..
+- mkdir -p $HOME/.config/ImageMagick
+- cp test/policy.xml $HOME/.config/ImageMagick
+- sudo rm -f /etc/ImageMagick-6/policy.xml # workaround
 script:
 - cd test
 - ./run_tests.sh
 jobs:
   include:
   - install:
-    - export CXX=g++-4.9
-    - export CC=gcc-4.9
     - cd external
     - "./build-external.sh"
     - cd ..
     - make -j2
   - install:
-    - export CXX=g++-4.9
-    - export CC=gcc-4.9
     - CMAKE_PREFIX_PATH=$ROOTSYS cmake .
     - make -j2
 notifications:

--- a/test/policy.xml
+++ b/test/policy.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE policymap [
+  <!ELEMENT policymap (policy)+>
+  <!ATTLIST policymap xmlns CDATA #FIXED ''>
+  <!ELEMENT policy EMPTY>
+  <!ATTLIST policy xmlns CDATA #FIXED '' domain NMTOKEN #REQUIRED
+    name NMTOKEN #IMPLIED pattern CDATA #IMPLIED rights NMTOKEN #IMPLIED
+    stealth NMTOKEN #IMPLIED value CDATA #IMPLIED>
+]>
+<policymap>
+  <policy domain="delegate" rights="all" pattern="gs" />
+</policymap>


### PR DESCRIPTION
There have been some differences between the ROOT version in travis (6.06.02) and the ones most of us use, which is a bit annoying (you need to go back to an SLC6 CMSSW release to update the references).
In the mean time there are also ROOT binary distributions for the Travis platforms (same gcc and ubuntu releases), so I'd propose to try and use these.

PS: this may become a debug-by-travis PR, so apologies in advance for the notification noise