### PR TITLE
Filter files on era early; warn if a group does not exist

### DIFF
--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -93,7 +93,7 @@ namespace plotIt {
       // Key is group name, value is group histogram
       std::vector<std::pair<std::string, std::shared_ptr<TH1>>> group_histograms;
       for ( auto& file: m_plotIt.getFiles([this,index] ( const File& f ) {
-            return m_plotIt.filter_eras(f) && ( f.type == MC ) && ( f.stack_index == index )
+            return ( f.type == MC ) && ( f.stack_index == index )
                 && ( ! f.legend_group.empty() ) && ( dynamic_cast<TH1*>(f.object)->GetEntries() != 0 );
             } ) ) {
           TH1* nominal = dynamic_cast<TH1*>(file.object);
@@ -113,7 +113,7 @@ namespace plotIt {
       std::vector<std::tuple<TH1*, std::string>> histograms_in_stack;
 
       for ( auto& file: m_plotIt.getFiles([this,index] ( const File& f ) {
-            return m_plotIt.filter_eras(f) && ( f.type == MC ) && ( f.stack_index == index )
+            return ( f.type == MC ) && ( f.stack_index == index )
                 && ( ! ( ( dynamic_cast<TH1*>(f.object)->GetEntries() == 0 ) && (f.legend_group.empty()) ) );
             } ) ) {
 
@@ -186,8 +186,7 @@ namespace plotIt {
       std::map<std::string, std::vector<float>> combined_systematics_map;
 
       for ( auto& file: m_plotIt.getFiles([this,index] ( const File& f ) {
-            return m_plotIt.filter_eras(f)
-                && ( f.type != DATA ) && ( ! f.systematics->empty() )
+            return ( f.type != DATA ) && ( ! f.systematics->empty() )
                 && ( ( f.type != MC ) || ( f.stack_index == index ) ) ;
             } ) ) {
 

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -506,7 +506,9 @@ namespace plotIt {
             parseFileNode(file, *it);
 
         file.id = process_id++;
-        m_files.push_back(file);
+        if ( filter_eras(file) ) {
+          m_files.push_back(file);
+        }
     }
 
     if (! expandFiles())
@@ -963,16 +965,14 @@ namespace plotIt {
     bool hasLegend = false;
     // Open all files, and find histogram in each
     for (File& file: m_files) {
-      if ( filter_eras(file) ) {
-        if (! loadObject(file, plot)) {
-          return false;
-        }
-
-        hasLegend |= getPlotStyle(file)->legend.length() > 0;
-        hasData |= file.type == DATA;
-        hasMC |= file.type == MC;
-        hasSignal |= file.type == SIGNAL;
+      if (! loadObject(file, plot)) {
+        return false;
       }
+
+      hasLegend |= getPlotStyle(file)->legend.length() > 0;
+      hasData |= file.type == DATA;
+      hasMC |= file.type == MC;
+      hasSignal |= file.type == SIGNAL;
     }
 
     // Can contains '/' if the plot is inside a folder
@@ -987,9 +987,11 @@ namespace plotIt {
         c.SetFrameFillStyle(4000);
     }
 
-    auto aFileIt = std::begin(m_files);
-    while ( ( aFileIt != std::end(m_files) ) && ( ! filter_eras(*aFileIt) ) ) { ++aFileIt; }
-    boost::optional<Summary> summary = ::plotIt::plot(*aFileIt, c, plot);
+    if ( m_files.empty() ) {
+      std::cout << "No files selected" << std::endl;
+      return false;
+    }
+    boost::optional<Summary> summary = ::plotIt::plot(m_files[0], c, plot);
 
     if (! summary)
       return false;
@@ -1170,9 +1172,6 @@ namespace plotIt {
 
       // Open all files, and find histogram in each
       for (auto& file: m_files) {
-        if ( ! filter_eras(file) )
-          continue;
-
         if (! loadObject(file, plot)) {
           std::cout << "Could not retrieve plot from " << file.path << std::endl;
           return false;

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -557,6 +557,7 @@ namespace plotIt {
     // Remove non-existant groups from files and update yields group
     for (auto& file: m_files) {
       if (!file.legend_group.empty() && !m_legend_groups.count(file.legend_group)) {
+        std::cout << "Warning: group " << file.legend_group << " (used for file " << file.pretty_name << ") not found, ignoring" << std::endl;
         file.legend_group = "";
       }
 


### PR DESCRIPTION
A fix and a minor new feature:
- filter files by era when reading the yml (instead of at every use), this is a more robust implementation of https://github.com/cp3-llbb/plotIt/pull/115 and fixes the issue of legends with missing color boxes if using only specific eras (reported by @swertz )
- print a warning when a file uses a group that is not defined (usually a typo in the config, but sometimes hard to find - reported by @kjaffel )