### PR TITLE
Free memory by loading objects only for some plots at once

### DIFF
--- a/include/plotIt.h
+++ b/include/plotIt.h
@@ -90,11 +90,11 @@ namespace plotIt {
 
       // Plot method
       bool plot(Plot& plot);
-      bool yields(std::vector<Plot>& plots);
+      bool yields(std::vector<Plot>::iterator plots_begin, std::vector<Plot>::iterator plots_end);
 
       bool expandFiles();
       bool expandObjects(File& file, std::vector<Plot>& plots);
-      bool loadAllObjects(File& file, const std::vector<Plot>& plots);
+      bool loadAllObjects(File& file, std::vector<Plot>::const_iterator plots_begin, std::vector<Plot>::const_iterator plots_end);
       bool loadObject(File& file, const Plot& plot);
 
       void fillLegend(TLegend& legend, const Plot& plot, bool with_uncertainties);

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -1547,6 +1547,11 @@ namespace plotIt {
       }
     }
 
+    if (!m_config.book_keeping_file_name.empty()) {
+      fs::path outputName = m_outputPath / m_config.book_keeping_file_name;
+      m_config.book_keeping_file.reset(TFile::Open(outputName.native().c_str(), "recreate"));
+    }
+
     if (CommandLineCfg::get().verbose)
         std::cout << "Loading all plots..." << std::endl;
 
@@ -1561,24 +1566,19 @@ namespace plotIt {
     if (CommandLineCfg::get().verbose)
         std::cout << "done." << std::endl;
 
-    if (!m_config.book_keeping_file_name.empty()) {
-      fs::path outputName = m_outputPath / m_config.book_keeping_file_name;
-      m_config.book_keeping_file.reset(TFile::Open(outputName.native().c_str(), "recreate"));
-    }
-
     if (CommandLineCfg::get().do_plots) {
       for (Plot& plot: plots) {
         plotIt::plot(plot);
       }
     }
 
+    if (CommandLineCfg::get().do_yields) {
+      plotIt::yields(plots);
+    }
+
     if (m_config.book_keeping_file) {
       m_config.book_keeping_file->Close();
       m_config.book_keeping_file.reset();
-    }
-
-    if (CommandLineCfg::get().do_yields) {
-      plotIt::yields(plots);
     }
   }
 
@@ -1613,8 +1613,9 @@ namespace plotIt {
         return true;
     }
 
-    file.handle.reset(TFile::Open(file.path.c_str()));
-    if (! file.handle.get())
+    if (! file.handle)
+      file.handle.reset(TFile::Open(file.path.c_str()));
+    if (! file.handle)
       return false;
 
     file.systematics_cache.clear();


### PR DESCRIPTION
I put a fixed number (100, wild guess) because it was the easiest to implement, in principle this could be made smarter (`loadAllObjects` could take the end of the vector and return the start of the part that still needs to be processed).

Testing done: memory usage stays below 3GB for the config from @kjaffel that got killed at 28GB (and half way through the plots) this morning - it seems to be running and the outputs look reasonable, but more detailed testing and validation is certainly welcome.