### PR TITLE
Fix bug when legend entry is not present or empty

### DIFF
--- a/include/utilities.h
+++ b/include/utilities.h
@@ -71,7 +71,7 @@ namespace plotIt {
       object->SetTitleSize(TITLE_FONTSIZE, "XYZ");
 
       object->GetYaxis()->SetNdivisions(510);
-      object->GetYaxis()->SetTitleOffset(2.5);
+      object->GetYaxis()->SetTitleOffset(1.5);
       object->GetYaxis()->SetLabelOffset(0.01);
       object->GetYaxis()->SetTickLength(0.03);
       object->GetYaxis()->SetLabelSize(plot.y_axis_label_size);

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -885,8 +885,7 @@ namespace plotIt {
               entry = {file.object, plot_style->legend, plot_style->legend_style, plot_style->legend_order};
           } else if (file.plot_style.get() && file.plot_style->legend.length() > 0) {
               entry = {file.object, file.plot_style->legend, file.plot_style->legend_style, file.plot_style->legend_order};
-          }
-          else{
+          } else {
             return false;
           }
 

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -886,6 +886,9 @@ namespace plotIt {
           } else if (file.plot_style.get() && file.plot_style->legend.length() > 0) {
               entry = {file.object, file.plot_style->legend, file.plot_style->legend_style, file.plot_style->legend_order};
           }
+          else{
+            return false;
+          }
 
           return true;
       };


### PR DESCRIPTION
In case of signal files, when the legend entry is not present or an empty string, the legend has an empty entry, which is not really useful. Also when several signal samples are plotted but without legend entries the legend on the plot becomes unreadable.

When it is a group that has no legend there are as many empty lines in the legend as there are files in the group, so it sounded like a bug.

I also corrected the `object->GetYaxis()->SetTitleOffset(2.5);` that made all my plots y label outside of the TCanvas. Not sure it is something people want to have included in the master branch.

Mildly related to that, I needed this fix because I want to have some signal samples in the config yaml file for bookkeeping among other things, but not plotted because there are a lot of them and it makes the plot too heavy. So on top of the signals not being in the legend I changed the line color to transparent `#01000000`. Funnily enough (don't know if it is root or plotIt related) the two first numbers are the alpha value and using 00 (alpha = 0%) makes it fully opaque while 01 (alpha = 1%) make is transparent. 