### PR TITLE
Normalise bin content by bin width

### DIFF
--- a/include/types.h
+++ b/include/types.h
@@ -283,7 +283,7 @@ namespace plotIt {
     bool no_data = false;
     bool override = false; // flag to plot only those which have it true (if at least one plot has it true)
     bool normalized = false;
-    bool normalizedPerBinWidth = false;
+    bool normalizedByBinWidth = false;
     bool log_y = false;
     bool log_x = false;
 

--- a/include/types.h
+++ b/include/types.h
@@ -283,6 +283,7 @@ namespace plotIt {
     bool no_data = false;
     bool override = false; // flag to plot only those which have it true (if at least one plot has it true)
     bool normalized = false;
+    bool normalizedPerBinWidth = false;
     bool log_y = false;
     bool log_x = false;
 

--- a/include/utilities.h
+++ b/include/utilities.h
@@ -50,8 +50,25 @@ namespace plotIt {
         float binSize = object->GetXaxis()->GetBinWidth(1);
         std::string title = plot.y_axis;
 
-        boost::format formatter = get_formatter(plot.y_axis_format);
-        object->GetYaxis()->SetTitle((formatter % title % binSize).str().c_str());
+        bool isEquidistantBinning = true;
+        for(int i = 2; i <= object->GetXaxis()->GetNbins(); ++i) {
+          if(object->GetXaxis()->GetBinWidth(1)!=object->GetXaxis()->GetBinWidth(i))
+            isEquidistantBinning = false;
+        }
+
+        if(isEquidistantBinning){
+          boost::format formatter = get_formatter(plot.y_axis_format);
+          object->GetYaxis()->SetTitle((formatter % title % binSize).str().c_str());
+        }
+        else if(plot.normalizedByBinWidth){
+          std::string format_string = "%1%/%2%";
+          boost::format formatter = get_formatter(format_string);
+          object->GetYaxis()->SetTitle((formatter % title % "Bin width").str().c_str());
+        }
+        else{
+          boost::format formatter = get_formatter(plot.y_axis_format);
+          object->GetYaxis()->SetTitle((formatter % title % binSize).str().c_str());
+        }
       }
 
       if (plot.show_ratio && object->GetXaxis())

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -458,7 +458,7 @@ namespace plotIt {
         computeSystematics(mc_stacks, global_summary);
     }
 
-    if (plot.normalizedPerBinWidth) {
+    if (plot.normalizedByBinWidth) {
         // Normalize each plot
         for (auto& file: m_plotIt.getFiles()) {
             if (file.type == SIGNAL) {

--- a/src/TH1Plotter.cc
+++ b/src/TH1Plotter.cc
@@ -458,6 +458,31 @@ namespace plotIt {
         computeSystematics(mc_stacks, global_summary);
     }
 
+    if (plot.normalizedPerBinWidth) {
+        // Normalize each plot
+        for (auto& file: m_plotIt.getFiles()) {
+            if (file.type == SIGNAL) {
+                TH1* h = dynamic_cast<TH1*>(file.object);
+                h->Scale(1.,"width");
+            }
+        }
+
+        if (h_data.get()) {
+            h_data->Scale(1.,"width");
+        }
+
+        std::for_each(mc_stacks.begin(), mc_stacks.end(), [](TH1Plotter::Stacks::value_type& value) {
+            TIter next(value.second.stack->GetHists());
+            TH1* h = nullptr;
+            while ((h = static_cast<TH1*>(next()))) {
+                h->Scale(1.,"width");
+            }
+            value.second.stat_and_syst->Scale(1.,"width");
+            value.second.syst_only->Scale(1.,"width");
+            value.second.stat_only->Scale(1.,"width");
+        });
+    }
+
     // Store all the histograms to draw, and find the one with the highest maximum
     std::vector<std::pair<TObject*, std::string>> toDraw = { std::make_pair(h_data.get(), data_drawing_options) };
     for (File& signal: signal_files) {

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -619,8 +619,8 @@ namespace plotIt {
       if (node["normalized"])
         plot.normalized = node["normalized"].as<bool>();
 
-      if (node["normalizedPerBinWidth"])
-        plot.normalizedPerBinWidth = node["normalizedPerBinWidth"].as<bool>();
+      if (node["normalizedByBinWidth"])
+        plot.normalizedByBinWidth = node["normalizedByBinWidth"].as<bool>();
 
       if (node["no-data"])
         plot.no_data = node["no-data"].as<bool>();

--- a/src/plotIt.cc
+++ b/src/plotIt.cc
@@ -619,6 +619,9 @@ namespace plotIt {
       if (node["normalized"])
         plot.normalized = node["normalized"].as<bool>();
 
+      if (node["normalizedPerBinWidth"])
+        plot.normalizedPerBinWidth = node["normalizedPerBinWidth"].as<bool>();
+
       if (node["no-data"])
         plot.no_data = node["no-data"].as<bool>();
 


### PR DESCRIPTION
In some cases, the user of plotIt may want to normalise bin content by the bin width.
This is now possible.